### PR TITLE
Fix url cache

### DIFF
--- a/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
+++ b/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
@@ -151,6 +151,7 @@ public class DefaultClient implements Client {
                 " --add-opens java.base/java.io=ALL-UNNAMED"
                         + " --add-opens java.base/java.lang=ALL-UNNAMED"
                         + " --add-opens java.base/java.util=ALL-UNNAMED"
+                        + " --add-opens java.base/sun.net.www.protocol.jar=ALL-UNNAMED"
                         + " --add-opens java.base/sun.nio.fs=ALL-UNNAMED");
     }
 

--- a/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
@@ -15,7 +15,6 @@
  */
 package org.mvndaemon.mvnd.common;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -26,10 +25,6 @@ import java.util.stream.Stream;
 public class MavenDaemon {
 
     public static void main(String[] args) throws Exception {
-        // Disable URL caching so that  the JVM does not try to cache resources
-        // loaded from jars that are built by a previous run
-        new File("txt").toURI().toURL().openConnection().setDefaultUseCaches(false);
-
         final Path mvndHome = Environment.MVND_HOME.asPath();
         URL[] classpath = Stream.concat(
                 /* jars */

--- a/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
@@ -168,14 +168,7 @@ public class Server implements AutoCloseable, Runnable {
                     try {
                         registry.close();
                     } finally {
-                        try {
-                            socket.close();
-                        } finally {
-                            if (!noDaemon) {
-                                clearCache("sun.net.www.protocol.jar.JarFileFactory", "urlCache");
-                                clearCache("sun.net.www.protocol.jar.JarFileFactory", "fileCache");
-                            }
-                        }
+                        socket.close();
                     }
                 }
             }
@@ -193,6 +186,7 @@ public class Server implements AutoCloseable, Runnable {
             cache.clear();
         } catch (Throwable t) {
             // ignore
+            LOGGER.warn("Error clearing cache {}.{}", clazzName, fieldName, t);
         }
     }
 
@@ -263,6 +257,11 @@ public class Server implements AutoCloseable, Runnable {
             }
         } catch (Throwable t) {
             LOGGER.error("Error reading request", t);
+        } finally {
+            if (!noDaemon) {
+                clearCache("sun.net.www.protocol.jar.JarFileFactory", "urlCache");
+                clearCache("sun.net.www.protocol.jar.JarFileFactory", "fileCache");
+            }
         }
     }
 


### PR DESCRIPTION
This fixes a few things:
  * the clearCache was not working because the reflection access was forbidden, this may fix a bunch of problem on windows and the clearCache should be called after a maven execution, not only when the daemon is closed  could that fix https://github.com/mvndaemon/mvnd/issues/115 ?)
  * revert the url cache to its default value (should fix https://github.com/mvndaemon/mvnd/issues/527)
