### PR TITLE
Fastclean extension

### DIFF
--- a/fastclean/pom.xml
+++ b/fastclean/pom.xml
@@ -1,0 +1,113 @@
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvndaemon.mvnd</groupId>
+        <artifactId>mvnd</artifactId>
+        <version>0.7.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mvnd-fastclean-maven-plugin</artifactId>
+
+    <packaging>maven-plugin</packaging>
+    <name>Maven Daemon - FastClean Maven Plugin</name>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+
+        <roaster.version>2.22.2.Final</roaster.version>
+        <maven.plugin-tools.version>3.6.0</maven.plugin-tools.version>
+        <maven-plugin-plugin.version>${maven.plugin-tools.version}</maven-plugin-plugin.version>
+        <maven.version>3.6.0</maven.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven.plugin-tools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.forge.roaster</groupId>
+            <artifactId>roaster-jdt</artifactId>
+            <version>${roaster.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>${maven-plugin-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>mvnd-build</goalPrefix>
+                    <mojoDependencies>
+                        <dep>org.apache.maven:maven-plugin-api</dep>
+                    </mojoDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/fastclean/src/main/java/org/mvndaemon/mvnd/plugin/fastclean/FastCleanLifecycleProvider.java
+++ b/fastclean/src/main/java/org/mvndaemon/mvnd/plugin/fastclean/FastCleanLifecycleProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.plugin.fastclean;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.apache.maven.eventspy.AbstractEventSpy;
+import org.apache.maven.lifecycle.DefaultLifecycles;
+import org.apache.maven.lifecycle.mapping.LifecyclePhase;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@Named
+public final class FastCleanLifecycleProvider extends AbstractEventSpy {
+
+    @Inject
+    public FastCleanLifecycleProvider(DefaultLifecycles defaultLifecycles) {
+        LoggerFactory.getLogger(getClass()).warn("FastCleanLifecycleProvider initialized");
+
+        defaultLifecycles.get("clean").getDefaultLifecyclePhases()
+                .put("clean", new LifecyclePhase("org.mvndaemon.mvnd:mvnd-fastclean-maven-plugin:clean"));
+    }
+
+}

--- a/fastclean/src/main/java/org/mvndaemon/mvnd/plugin/fastclean/FastCleanMojo.java
+++ b/fastclean/src/main/java/org/mvndaemon/mvnd/plugin/fastclean/FastCleanMojo.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.plugin.fastclean;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.stream.Stream;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Extracts JavaDoc blocks from enum entries and stores them into a properties file.
+ */
+@Mojo(name = "clean", defaultPhase = LifecyclePhase.CLEAN, threadSafe = true, requiresProject = true, requiresDependencyResolution = ResolutionScope.NONE)
+public class FastCleanMojo extends AbstractMojo {
+
+    /**
+     * This is where build results go.
+     */
+    @Parameter(defaultValue = "${project.build.directory}", readonly = true, required = true)
+    private File dir;
+
+    /**
+     * Sets whether the plugin runs in verbose mode. As of plugin version 2.3, the default value is derived from Maven's
+     * global debug flag (compare command line switch <code>-X</code>). <br/>
+     * Starting with <b>3.0.0</b> the property has been renamed from <code>clean.verbose</code> to
+     * <code>maven.clean.verbose</code>.
+     */
+    @Parameter(property = "maven.clean.verbose")
+    private Boolean verbose;
+
+    /**
+     * Disables the plugin execution. <br/>
+     */
+    @Parameter(property = "maven.clean.skip", defaultValue = "false")
+    private boolean skip;
+
+    /**
+     * Indicates whether the build will continue even if there are clean errors.
+     */
+    @Parameter(property = "maven.clean.failOnError", defaultValue = "true")
+    private boolean failOnError;
+
+    /**
+     * Indicates whether the plugin should undertake additional attempts (after a short delay) to delete a file if the
+     * first attempt failed. This is meant to help deleting files that are temporarily locked by third-party tools like
+     * virus scanners or search indexing.
+     */
+    @Parameter(property = "maven.clean.retryOnError", defaultValue = "true")
+    private boolean retryOnError;
+
+    @Override
+    public void execute() throws MojoFailureException {
+        final Log log = getLog();
+        if (skip) {
+            log.info(getClass().getSimpleName() + " skipped per skip parameter");
+            return;
+        }
+
+        Path directory = dir.toPath();
+        if (Files.exists(directory)) {
+            if (Files.isDirectory(directory)) {
+                String random = Long.toHexString(new Random().nextLong());
+                String name = directory.getFileName().toString() + "-" + random;
+                Path tmpDir = directory.resolveSibling(name);
+                Path delDir = directory.resolve(name);
+                try {
+                    Files.move(directory, tmpDir);
+                    Files.createDirectory(directory);
+                    Files.move(tmpDir, delDir);
+                } catch (IOException e) {
+                    error("Unable to move " + directory, e);
+                }
+                new Thread(() -> deleteDir(delDir, retryOnError)).run();
+            } else {
+                error("The path " + directory + " is not a directory", null);
+            }
+        }
+    }
+
+    private void error(String message, Throwable cause) throws MojoFailureException {
+        if (failOnError) {
+            if (cause == null) {
+                throw new MojoFailureException(message);
+            } else {
+                throw new MojoFailureException(message, cause);
+            }
+        } else {
+            getLog().warn(message);
+        }
+    }
+
+    public void deleteDir(Path dir, boolean retryOnError) {
+        if (Files.exists(dir)) {
+            boolean result = false;
+            try (Stream<Path> files = Files.walk(dir)) {
+                result = files.sorted(Comparator.reverseOrder())
+                        .map(this::deleteFile)
+                        .allMatch(b -> b);
+            } catch (IOException e) {
+                // ignore
+            }
+            if (!result) {
+                if (retryOnError) {
+                    deleteDir(dir, false);
+                } else {
+                    getLog().warn("Error deleting directory " + dir);
+                }
+            }
+        }
+    }
+
+    private boolean deleteFile(Path f) {
+        try {
+            Files.delete(f);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <module>daemon</module>
         <module>sync</module>
         <module>dist</module>
+        <module>fastclean</module>
         <module>integration-tests</module>
     </modules>
 


### PR DESCRIPTION
Fast clean extension.

It needs to be registered as an extension, so either in `.mvn/extensions` with
```
<extensions>
    <extension>
        <groupId>org.mvndaemon.mvnd</groupId>
        <artifactId>mvnd-fastclean-maven-plugin</artifactId>
        <version>0.7.2-SNAPSHOT</version>
    </extension>
</extensions>
```

or inside the pom with:
```
<build>
    <extensions>
      <extension>
        <groupId>org.mvndaemon.mvnd</groupId>
        <artifactId>mvnd-fastclean-maven-plugin</artifactId>
        <version>0.7.2-SNAPSHOT</version>
      </extension>
    </extensions>
</build>
```

@atlib77 let me know how this works for you.