### PR TITLE
Fixes url for GraalVM's native-image prerequisites

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -189,7 +189,7 @@ $ $JAVA_HOME/bin/gu install native-image
 ----
 
 * `native-image` may require additional software to be installed depending on your platform - see the
-https://www.graalvm.org/docs/reference-manual/native-image/#prerequisites[`native-image` documentation].
+https://www.graalvm.org/reference-manual/native-image/#prerequisites[`native-image` documentation].
 
 === Build `mvnd`
 


### PR DESCRIPTION
The change fixes link to the GraalVM's native-image documentation that has been changed.