### PR TITLE
Upgrades logback to the newest version to fix CVE-2021-42550

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <jansi.version>2.4.0</jansi.version>
         <jline.version>3.21.0</jline.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.10</logback.version>
         <maven.version>3.8.4</maven.version>
         <maven.resolver.version>1.7.2</maven.resolver.version>
         <slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION
Even if the attack vector for the [CVE-2021-42550](https://nvd.nist.gov/vuln/detail/CVE-2021-42550) is very limited in mvnd, I think it's worth to have the newest version of logback.