### PR TITLE
introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: '/'
+    schedule:
+      interval: daily
+    # see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit
+    # open-pull-requests-limit: 10
+    versioning-strategy: increase


### PR DESCRIPTION
Regarding recent supply chain attacks having a decent mechanism to easily integrate updates seems to me very important.

This adds github own mechanism. An alternative would be whitesource.