### PR TITLE
Upgrade SLF4J to version 1.7.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <logback.version>1.2.10</logback.version>
         <maven.version>3.8.4</maven.version>
         <maven.resolver.version>1.7.2</maven.resolver.version>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.35</slf4j.version>
 
         <!-- plugin versions a..z -->
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>


### PR DESCRIPTION
2022-01-13 - Release of SLF4J 1.7.33

• SLF4J now ships with the slf4j-reload4j module delegating to the reload4j backend. Reload4j is a drop-in replacement for log4j version 1.2.17.

• SimpleLogger now prints the thread Id if instructed to do so. This fixes SLF4J-499 requested by Michael Osipov