### PR TITLE
Fix mvn/bin/mvn debug output

### DIFF
--- a/daemon/src/main/java/org/mvndaemon/mvnd/logging/internal/MvndSlf4jConfiguration.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/logging/internal/MvndSlf4jConfiguration.java
@@ -16,10 +16,27 @@
 package org.mvndaemon.mvnd.logging.internal;
 
 import org.apache.maven.cli.logging.Slf4jConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MvndSlf4jConfiguration implements Slf4jConfiguration {
     @Override
     public void setRootLoggerLevel(Level level) {
+        ch.qos.logback.classic.Level value;
+        switch (level) {
+        case DEBUG:
+            value = ch.qos.logback.classic.Level.DEBUG;
+            break;
+
+        case INFO:
+            value = ch.qos.logback.classic.Level.INFO;
+            break;
+
+        default:
+            value = ch.qos.logback.classic.Level.ERROR;
+            break;
+        }
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(value);
     }
 
     @Override


### PR DESCRIPTION
The maven invoker uses debug output by default when running integration tests.
However, mvnd does not support the '-X' flag in this case.