### PR TITLE
only publish sha256, skip md5+sha1+sha512

### DIFF
--- a/build/publish.sh
+++ b/build/publish.sh
@@ -51,9 +51,6 @@ cd ${VERSION}
 for dist in darwin-amd64.zip linux-amd64.zip windows-amd64.zip src.zip src.tar.gz
 do
   FILE=mvnd-${VERSION}-${dist}
-  md5 -q ${FILE} > ${FILE}.md5
-  shasum -a 1 -b ${FILE} | cut -d ' ' -f 1 > ${FILE}.sha1
-  shasum -a 256 -b ${FILE} | cut -d ' ' -f 1 > ${FILE}.sha256
   shasum -a 512 -b ${FILE} | cut -d ' ' -f 1 > ${FILE}.sha512
   gpg --detach-sign --armor ${FILE}
 done

--- a/build/publish.sh
+++ b/build/publish.sh
@@ -51,7 +51,7 @@ cd ${VERSION}
 for dist in darwin-amd64.zip linux-amd64.zip windows-amd64.zip src.zip src.tar.gz
 do
   FILE=mvnd-${VERSION}-${dist}
-  shasum -a 512 -b ${FILE} | cut -d ' ' -f 1 > ${FILE}.sha512
+  shasum -a 256 -b ${FILE} | cut -d ' ' -f 1 > ${FILE}.sha256
   gpg --detach-sign --armor ${FILE}
 done
 


### PR DESCRIPTION
ASF does not need md5 nor sha1 nor sha256: only .asc and .sha512