### PR TITLE
Configure execution bit for required scripts in source distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Build source distribution'
-        run: ./mvnw clean verify -Psource-distribution -pl :mvnd -Dmrm=false -B -ntp -e
+        run: ./mvnw clean verify -Psource-distribution -N -B -ntp -e
 
       - name: 'Upload artifact'
         uses: actions/upload-artifact@v2

--- a/src/main/assembly/src.xml
+++ b/src/main/assembly/src.xml
@@ -28,6 +28,16 @@ under the License.
     <fileSet>
       <directory>${project.basedir}</directory>
       <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>mvnw</include>
+        <include>native/docker/*</include>
+        <include>build/*.sh</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <outputDirectory>/</outputDirectory>
       <excludes>
         <exclude>%regex[(?!((?!target/)[^/]+/)*src/).*target.*]</exclude>
         <exclude>**/*.log</exclude>


### PR DESCRIPTION
without these, you can't immediately build as you do from Git checkout