### PR TITLE
Update GraalVM to 22.2.0

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -24,7 +24,7 @@ on:
   pull_request:
 
 env:
-  GRAALVM_VERSION: '21.3.0'
+  GRAALVM_VERSION: '22.2.0'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ on:
       - '*'
 
 env:
-  GRAALVM_VERSION: '21.3.0'
+  GRAALVM_VERSION: '22.2.0'
   JAVA_VERSION: '17'
 
 jobs:

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -75,6 +75,27 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-bytecode-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <excludes>
+                                        <exclude>org.graalvm.nativeimage:svm</exclude>
+                                    </excludes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
                 <configuration>
@@ -118,12 +139,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.graalvm.nativeimage</groupId>
-                        <artifactId>native-image-maven-plugin</artifactId>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <goals>
-                                    <goal>native-image</goal>
+                                    <goal>build</goal>
                                 </goals>
                                 <phase>package</phase>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <apiguardian-api.version>1.0.0</apiguardian-api.version>
         <assertj.version>3.16.1</assertj.version>
         <commons-compress.version>1.21</commons-compress.version>
-        <graalvm.version>21.3.0</graalvm.version>
-        <graalvm.plugin.version>21.2.0</graalvm.plugin.version>
+        <graalvm.version>22.2.0</graalvm.version>
+        <graalvm.plugin.version>0.9.13</graalvm.plugin.version>
         <groovy.version>3.0.9</groovy.version>
         <jakarta.inject.version>1.0</jakarta.inject.version>
         <jansi.version>2.4.0</jansi.version>
@@ -474,8 +474,8 @@ limitations under the License.</inlineHeader>
                     <version>${buildnumber-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.graalvm.nativeimage</groupId>
-                    <artifactId>native-image-maven-plugin</artifactId>
+                    <groupId>org.graalvm.buildtools</groupId>
+                    <artifactId>native-maven-plugin</artifactId>
                     <version>${graalvm.plugin.version}</version>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Apple Silicon is only supported since 22.1.0 https://www.graalvm.org/release-notes/22_1/#platform-updates so an upgrade to 22.x is necessary to build Mac AArch64 binaries.