### PR TITLE
Release the read lock in a finally block

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
@@ -469,14 +469,17 @@ public class TerminalOutput implements ClientOutput {
         try {
             while (!closing) {
                 if (readInput.readLock().tryLock(10, TimeUnit.MILLISECONDS)) {
-                    int c = terminal.reader().read(10);
-                    if (c == -1) {
-                        break;
+                    try {
+                        int c = terminal.reader().read(10);
+                        if (c == -1) {
+                            break;
+                        }
+                        if (c == KEY_PLUS || c == KEY_MINUS || c == KEY_CTRL_L || c == KEY_CTRL_M || c == KEY_CTRL_B) {
+                            daemonReceive.accept(Message.keyboardInput((char) c));
+                        }
+                    } finally {
+                        readInput.readLock().unlock();
                     }
-                    if (c == KEY_PLUS || c == KEY_MINUS || c == KEY_CTRL_L || c == KEY_CTRL_M || c == KEY_CTRL_B) {
-                        daemonReceive.accept(Message.keyboardInput((char) c));
-                    }
-                    readInput.readLock().unlock();
                 }
             }
         } catch (InterruptedException e) {


### PR DESCRIPTION
## Motivation

In case of an error, the read lock is never released which would prevent subsequent write locks.

## Modifications:

* Release the read lock in a finally block to ensure that it will be released in any case.