### PR TITLE
Sync entry scripts with maven 3.8.6

### DIFF
--- a/dist/src/main/distro/bin/mvnd.cmd
+++ b/dist/src/main/distro/bin/mvnd.cmd
@@ -35,8 +35,8 @@
 @REM Execute a user defined script before this one
 if not "%MAVEN_SKIP_RC%"=="" goto skipRcPre
 @REM check for pre script, once with legacy .bat ending and once with .cmd ending
-if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat"
-if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd"
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
 :skipRcPre
 
 @setlocal
@@ -54,20 +54,15 @@ set "JAVACMD=%JAVA_HOME%\bin\java.exe"
 :checkJCmd
 if exist "%JAVACMD%" goto chkMHome
 
-echo The JAVA_HOME environment variable is not defined correctly >&2
-echo This environment variable is needed to run this program >&2
-echo NB: JAVA_HOME should point to a JDK not a JRE >&2
+echo The JAVA_HOME environment variable is not defined correctly, >&2
+echo this environment variable is needed to run this program. >&2
 goto error
 
 :chkMHome
-set "MVND_HOME=%~dp0.."
-if not "%MVND_HOME%"=="" goto stripMHome
+set "MVND_HOME=%~dp0"
+set "MVND_HOME=%MVND_HOME:~0,-5%"
+if not "%MVND_HOME%"=="" goto checkMCmd
 goto error
-
-:stripMHome
-if not "_%MVND_HOME:~-1%"=="_\" goto checkMCmd
-set "MVND_HOME=%MVND_HOME:~0,-1%"
-goto stripMHome
 
 :checkMCmd
 if exist "%MVND_HOME%\bin\mvnd.cmd" goto init
@@ -93,7 +88,6 @@ set DAEMON_LAUNCHER=org.mvndaemon.mvnd.client.DefaultClient
   "-Dmvnd.home=%MVND_HOME%" ^
   "-Dmaven.home=%MVND_HOME%\mvn" ^
   "-Dlibrary.jansi.path=%MVND_HOME%\mvn\lib\jansi-native" ^
-  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
   %DAEMON_LAUNCHER% %MAVEN_CMD_LINE_ARGS%
 if ERRORLEVEL 1 goto error
 goto end

--- a/dist/src/main/distro/bin/mvnd.sh
+++ b/dist/src/main/distro/bin/mvnd.sh
@@ -90,15 +90,14 @@ if $mingw ; then
 fi
 
 if [ -z "$JAVA_HOME" ] ; then
-  JAVACMD=`which java`
+  JAVACMD="`\\unset -f command; \\command -v java`"
 else
   JAVACMD="$JAVA_HOME/bin/java"
 fi
 
 if [ ! -x "$JAVACMD" ] ; then
-  echo "The JAVA_HOME environment variable is not defined correctly" >&2
-  echo "This environment variable is needed to run this program" >&2
-  echo "NB: JAVA_HOME should point to a JDK not a JRE" >&2
+  echo "The JAVA_HOME environment variable is not defined correctly," >&2
+  echo "this environment variable is needed to run this program." >&2
   exit 1
 fi
 
@@ -140,7 +139,7 @@ find_file_argument_basedir() {
       fi
       break
     fi
-    if [ "$arg" = "-f" ] || [ "$arg" = "--file" ]; then
+    if [ "$arg" = "-f" -o "$arg" = "--file" ]; then
       found_file_switch=1
     fi
   done

--- a/dist/src/main/distro/mvn/bin/mvn
+++ b/dist/src/main/distro/mvn/bin/mvn
@@ -90,15 +90,14 @@ if $mingw ; then
 fi
 
 if [ -z "$JAVA_HOME" ] ; then
-  JAVACMD=`which java`
+  JAVACMD="`\\unset -f command; \\command -v java`"
 else
   JAVACMD="$JAVA_HOME/bin/java"
 fi
 
 if [ ! -x "$JAVACMD" ] ; then
-  echo "The JAVA_HOME environment variable is not defined correctly" >&2
-  echo "This environment variable is needed to run this program" >&2
-  echo "NB: JAVA_HOME should point to a JDK not a JRE" >&2
+  echo "The JAVA_HOME environment variable is not defined correctly," >&2
+  echo "this environment variable is needed to run this program." >&2
   exit 1
 fi
 

--- a/dist/src/main/distro/mvn/bin/mvn.cmd
+++ b/dist/src/main/distro/mvn/bin/mvn.cmd
@@ -35,8 +35,8 @@
 @REM Execute a user defined script before this one
 if not "%MAVEN_SKIP_RC%"=="" goto skipRcPre
 @REM check for pre script, once with legacy .bat ending and once with .cmd ending
-if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat"
-if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd"
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
 :skipRcPre
 
 @setlocal
@@ -54,20 +54,15 @@ set "JAVACMD=%JAVA_HOME%\bin\java.exe"
 :checkJCmd
 if exist "%JAVACMD%" goto chkMHome
 
-echo The JAVA_HOME environment variable is not defined correctly >&2
-echo This environment variable is needed to run this program >&2
-echo NB: JAVA_HOME should point to a JDK not a JRE >&2
+echo The JAVA_HOME environment variable is not defined correctly, >&2
+echo this environment variable is needed to run this program. >&2
 goto error
 
 :chkMHome
-set "MAVEN_HOME=%~dp0.."
-if not "%MAVEN_HOME%"=="" goto stripMHome
+set "MAVEN_HOME=%~dp0"
+set "MAVEN_HOME=%MAVEN_HOME:~0,-5%"
+if not "%MAVEN_HOME%"=="" goto checkMCmd
 goto error
-
-:stripMHome
-if not "_%MAVEN_HOME:~-1%"=="_\" goto checkMCmd
-set "MAVEN_HOME=%MAVEN_HOME:~0,-1%"
-goto stripMHome
 
 :checkMCmd
 if exist "%MAVEN_HOME%\bin\mvn.cmd" goto init
@@ -78,7 +73,7 @@ goto error
 
 set MAVEN_CMD_LINE_ARGS=%*
 
-@REM Find the project basedir, i.e., the directory that contains the folder ".mvn".
+@REM Find the project basedir, i.e., the directory that contains the directory ".mvn".
 @REM Fallback to current working directory if not found.
 
 set "MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%"
@@ -156,7 +151,7 @@ goto endDetectBaseDir
 :baseDirNotFound
 if "_%EXEC_DIR:~-1%"=="_\" set "EXEC_DIR=%EXEC_DIR:~0,-1%"
 set "MAVEN_PROJECTBASEDIR=%EXEC_DIR%"
-cd "%EXEC_DIR%"
+cd /d "%EXEC_DIR%"
 
 :endDetectBaseDir
 


### PR DESCRIPTION
The main change of the upstream scripts is removing the dependency of `which` command. This improve the portability.