### PR TITLE
Add property 'mvnd.preserveProjectLog' to not decorate the stdout/stderr stream

### DIFF
--- a/client/src/main/java-mvnd/org/mvndaemon/mvnd/client/DefaultClient.java
+++ b/client/src/main/java-mvnd/org/mvndaemon/mvnd/client/DefaultClient.java
@@ -148,7 +148,8 @@ public class DefaultClient implements Client {
 
         int exitCode = 0;
         boolean noBuffering = batchMode || parameters.noBuffering();
-        try (TerminalOutput output = new TerminalOutput(noBuffering, parameters.rollingWindowSize(), logFile)) {
+        try (TerminalOutput output = new TerminalOutput(
+                noBuffering, parameters.rollingWindowSize(), logFile, parameters.preserveProjectLog())) {
             try {
                 final ExecutionResult result = new DefaultClient(parameters).execute(output, args);
                 exitCode = result.getExitCode();

--- a/client/src/main/java/org/mvndaemon/mvnd/client/DaemonParameters.java
+++ b/client/src/main/java/org/mvndaemon/mvnd/client/DaemonParameters.java
@@ -321,6 +321,16 @@ public class DaemonParameters {
     }
 
     /**
+     * @return <code>true</code> if the stdout/stderr project log should be preserved.
+     */
+    public boolean preserveProjectLog() {
+        return value(Environment.MVND_PRESERVE_PROJECT_LOG)
+                .orSystemProperty()
+                .orDefault()
+                .asBoolean();
+    }
+
+    /**
      * @param  newUserDir where to change the current directory to
      * @return            a new {@link DaemonParameters} with {@code userDir} set to the given {@code newUserDir}
      */

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -122,6 +122,8 @@ public enum Environment {
     MAVEN_DEFINE(null, null, null, OptionType.STRING, Flags.INTERNAL, "mvn:-D", "mvn:--define"),
     /** Whether the output should be styled using ANSI color codes; possible values: auto, always, never */
     MAVEN_COLOR("style.color", null, "auto", OptionType.STRING, Flags.OPTIONAL, "mvnd:--color"),
+    /** Keep stdout/stderr log undecorated when not in --raw-streams mode. */
+    MVND_PRESERVE_PROJECT_LOG("mvnd.preserveProjectLog", null, Boolean.FALSE, OptionType.BOOLEAN, Flags.OPTIONAL),
 
     //
     // mvnd properties


### PR DESCRIPTION
With the new property set to `true`, the prefix `[INFO] [stdout] ` is removed in the client terminal output. Then without `--raw-stream`, we can still get the same behavior with original maven.