### PR TITLE
Reset system properties after calling event syps

### DIFF
--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
@@ -240,8 +240,8 @@ public class DaemonMavenCli {
         } catch (ExitException e) {
             return e.exitCode;
         } finally {
-            System.setProperties(props);
             eventSpyDispatcher.close();
+            System.setProperties(props);
             Thread.currentThread().setContextClassLoader(tccl);
         }
     }


### PR DESCRIPTION
Event spies may want to read system properties, which will fail if they are reset too early. This change makes the behavior consistent with regular Maven.