### PR TITLE
Build mostly static native image, loose linux glibc requirement to 2.12

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -66,9 +66,9 @@ jobs:
             echo "posix_spawn posix_spawn@GLIBC_2.2.5" >>client/target/glibc.redef
             find "$GRAALVM_HOME/lib/static/linux-amd64/glibc" -name '*.a' | while IFS= read -r input; do
               output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
-              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output"
+              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output" 2>/dev/null
             done
-            find /usr -name libz.a | head -n 1 | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+            find /usr -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
           fi
 
       - name: 'Build native distribution'

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -68,7 +68,7 @@ jobs:
               output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
               objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output" 2>/dev/null
             done
-            find /usr -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+            find /usr/lib -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
           fi
 
       - name: 'Build native distribution'

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -57,6 +57,9 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Maven clean'
+        run: ./mvnw clean -Dmrm=false -B -ntp -e
+
       - name: 'Patch Graal libs for only requiring glibc 2.12'
         shell: bash
         run: |
@@ -72,7 +75,7 @@ jobs:
           fi
 
       - name: 'Build native distribution'
-        run: ./mvnw clean verify -Pnative -Dmrm=false -B -ntp -e
+        run: ./mvnw verify -Pnative -Dmrm=false -B -ntp -e
 
       - name: 'Upload daemon test logs'
         if: always()

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -57,6 +57,20 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Patch Graal libs for only requiring glibc 2.12'
+        shell: bash
+        run: |
+          if [[ $OS == linux ]] && [[ $GRAALVM_HOME ]] && [[ -d "$GRAALVM_HOME/lib/static/linux-amd64/glibc" ]]; then
+            mkdir -p client/target/graalvm-libs-for-glibc-2.12
+            echo "memcpy memcpy@GLIBC_2.2.5" >client/target/glibc.redef
+            echo "posix_spawn posix_spawn@GLIBC_2.2.5" >>client/target/glibc.redef
+            find "$GRAALVM_HOME/lib/static/linux-amd64/glibc" -name '*.a' | while IFS= read -r input; do
+              output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
+              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output"
+            done
+            find /usr -name libz.a | head -n 1 | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+          fi
+
       - name: 'Build native distribution'
         run: ./mvnw clean verify -Pnative -Dmrm=false -B -ntp -e
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,9 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Maven clean'
+        run: ./mvnw clean -Dmrm=false -B -ntp -e
+
       - name: 'Patch Graal libs for only requiring glibc 2.12'
         shell: bash
         run: |
@@ -73,7 +76,7 @@ jobs:
           fi
 
       - name: 'Build native distribution'
-        run: ./mvnw clean verify -Pnative -Dmrm=false -B -ntp -e -DskipTests
+        run: ./mvnw verify -Pnative -Dmrm=false -B -ntp -e -DskipTests
 
       - name: 'Upload artifact'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,9 +67,9 @@ jobs:
             echo "posix_spawn posix_spawn@GLIBC_2.2.5" >>client/target/glibc.redef
             find "$GRAALVM_HOME/lib/static/linux-amd64/glibc" -name '*.a' | while IFS= read -r input; do
               output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
-              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output"
+              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output" 2>/dev/null
             done
-            find /usr -name libz.a | head -n 1 | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+            find /usr -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
           fi
 
       - name: 'Build native distribution'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,20 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Patch Graal libs for only requiring glibc 2.12'
+        shell: bash
+        run: |
+          if [[ $OS == linux ]] && [[ $GRAALVM_HOME ]] && [[ -d "$GRAALVM_HOME/lib/static/linux-amd64/glibc" ]]; then
+            mkdir -p client/target/graalvm-libs-for-glibc-2.12
+            echo "memcpy memcpy@GLIBC_2.2.5" >client/target/glibc.redef
+            echo "posix_spawn posix_spawn@GLIBC_2.2.5" >>client/target/glibc.redef
+            find "$GRAALVM_HOME/lib/static/linux-amd64/glibc" -name '*.a' | while IFS= read -r input; do
+              output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
+              objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output"
+            done
+            find /usr -name libz.a | head -n 1 | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+          fi
+
       - name: 'Build native distribution'
         run: ./mvnw clean verify -Pnative -Dmrm=false -B -ntp -e -DskipTests
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
               output="client/target/graalvm-libs-for-glibc-2.12/$(basename -- "$input")"
               objcopy --redefine-syms=client/target/glibc.redef -- "$input" "$output" 2>/dev/null
             done
-            find /usr -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
+            find /usr/lib -name libz.a | xargs -r -I {} objcopy --redefine-syms=client/target/glibc.redef {} client/target/graalvm-libs-for-glibc-2.12/libz.a
           fi
 
       - name: 'Build native distribution'

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -33,6 +33,8 @@
   <properties>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
+    <graalvm-native-static-opt/>
+    <graalvm-native-glibc-opt/>
   </properties>
 
   <dependencies>
@@ -134,8 +136,34 @@
 
   <profiles>
     <profile>
-      <id>native</id>
+      <id>enable-partial-static-native</id>
+      <activation>
+        <os>
+          <family>!mac</family>
+        </os>
+      </activation>
+      <properties>
+        <graalvm-native-static-opt>-H:+StaticExecutableWithDynamicLibC</graalvm-native-static-opt>
+      </properties>
+    </profile>
 
+    <profile>
+      <id>linux-image-only-require-glibc-2.12</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+        <file>
+          <exists>target/graalvm-libs-for-glibc-2.12</exists>
+        </file>
+      </activation>
+      <properties>
+        <graalvm-native-glibc-opt>-H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</graalvm-native-glibc-opt>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>
@@ -146,13 +174,16 @@
               <mainClass>org.mvndaemon.mvnd.client.DefaultClient</mainClass>
               <imageName>mvnd</imageName>
               <buildArgs>--no-server
-                                --no-fallback
-                                --allow-incomplete-classpath
-                                -H:IncludeResources=org/mvndaemon/mvnd/.*
-                                -H:IncludeResources=mvnd-bash-completion.bash
-                                -H:-ParseRuntimeOptions
-                                -H:+AddAllCharsets
-                                -ea</buildArgs>
+                         --no-fallback
+                         --allow-incomplete-classpath
+                         ${graalvm-native-static-opt}
+                         ${graalvm-native-glibc-opt}
+                         -H:IncludeResources=org/mvndaemon/mvnd/.*
+                         -H:IncludeResources=mvnd-bash-completion.bash
+                         -H:-ParseRuntimeOptions
+                         -H:+AddAllCharsets
+                         -H:+ReportExceptionStackTraces
+                         -ea</buildArgs>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
This pr improves native image portability on linux and windows via:
1. Enable mostly static image switch on linux and windows. on linux, the cost is about 33K file size before compressed, about +0.1%.
2. Loose linux `glibc` requirement to 2.12. Now the `mvnd` depends on many `JNI`s which are built by `glibc` toolchains, so we cannot easily switch to `musl` toolchains or a fully static image (discussed in #727 ). Whereas a lower glibc requirement adds support for most old linux boxes.

An explicit `glibc` requirement also removes a side effect of changing the build system. When update the build system from ubuntu 18.04 to 20.04, the glibc requirement may also increase to match the new os. On the other hand, glibc 2.12 is required by graalvm.