### PR TITLE
Improve the README file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -152,7 +152,7 @@ $ xattr -r -d com.apple.quarantine mvnd-x.y.z-darwin-amd64
 
 [source,shell]
 ----
-mvnd clean install
+mvnd verify
 ----
 
 == `mvnd` specific options


### PR DESCRIPTION
There is wide spread misconception that in order to build a Maven project the command is `mvn clean install`.

It would be better to promote the right way (in the vast majority of the cases) to build a Maven project.

`mvnd verify` aligns with Maven documentation as well, where the example command is `mvn verify`.

p.s. Sorry for the nitpicking and thanks for the hard work. The project is amazing. Just want to fix all `mvn clean install` examples where I see them 😃 