### PR TITLE
Resolver 1.9.0

### DIFF
--- a/daemon/src/main/java/org/apache/maven/internal/ResolverLifecycle.java
+++ b/daemon/src/main/java/org/apache/maven/internal/ResolverLifecycle.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.mvndaemon.mvnd.syncontext;
+package org.apache.maven.internal;
 
-import java.util.Map;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -28,7 +24,7 @@ import javax.inject.Singleton;
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -37,25 +33,32 @@ import javax.inject.Singleton;
  * specific language governing permissions and limitations
  * under the License.
  */
-import org.eclipse.aether.internal.impl.synccontext.named.FileGAVNameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
-import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactorySelectorSupport;
-import org.eclipse.aether.named.NamedLockFactory;
-import org.eclipse.aether.named.providers.FileLockNamedLockFactory;
-import org.eclipse.sisu.Priority;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.sisu.EagerSingleton;
+
+import static java.util.Objects.requireNonNull;
 
 /**
- * Mvnd selector implementation: it differs from
- * {@link org.eclipse.aether.internal.impl.synccontext.named.SimpleNamedLockFactorySelector} only by default values.
+ * Maven internal component that bridges container "shut down" to {@link RepositorySystem#shutdown()}.
+ *
+ * @since TBD
  */
-@Singleton
 @Named
-@Priority(10)
-public final class DaemonNamedLockFactorySelector
-        extends NamedLockFactorySelectorSupport {
+@EagerSingleton
+public final class ResolverLifecycle {
+    private final Provider<RepositorySystem> repositorySystemProvider;
+
     @Inject
-    public DaemonNamedLockFactorySelector(final Map<String, NamedLockFactory> factories,
-            final Map<String, NameMapper> nameMappers) {
-        super(factories, FileLockNamedLockFactory.NAME, nameMappers, FileGAVNameMapper.NAME);
+    public ResolverLifecycle(Provider<RepositorySystem> repositorySystemProvider) {
+        this.repositorySystemProvider = requireNonNull(repositorySystemProvider);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        repositorySystemProvider.get().shutdown();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
         <logback.version>1.2.10</logback.version>
         <maven.version>4.0.0-alpha-2</maven.version>
-        <maven.resolver.version>1.8.2</maven.resolver.version>
+        <maven.resolver.version>1.9.0</maven.resolver.version>
         <slf4j.version>1.7.35</slf4j.version>
         <sisu.version>0.3.5</sisu.version>
 


### PR DESCRIPTION
Resolver 1.9.0 has a breaking change MRESOLVER-284 that was later undone (in 1.9.1+). Hence, the
CLI changes are needd ONLY for 1.9.0 and shall be
removed on upgrade to later version.

Still, the patch is incomplete, as it merely sets
mvnd specific defaults, but does not allow
mvnd users to override locking (to HZ/redisson
for example).