### PR TITLE
Add more discriminating properties to the daemon

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -94,9 +94,16 @@ public enum Environment {
     // Maven properties
     //
     /** The path to the Maven local repository */
-    MAVEN_REPO_LOCAL("maven.repo.local", null, null, OptionType.PATH, Flags.NONE),
+    MAVEN_REPO_LOCAL("maven.repo.local", null, null, OptionType.PATH, Flags.DISCRIMINATING | Flags.OPTIONAL),
     /** The location of the maven settings file */
-    MAVEN_SETTINGS("maven.settings", null, null, OptionType.PATH, Flags.NONE, "mvn:-s", "mvn:--settings"),
+    MAVEN_SETTINGS(
+            "maven.settings",
+            null,
+            null,
+            OptionType.PATH,
+            Flags.DISCRIMINATING | Flags.OPTIONAL,
+            "mvn:-s",
+            "mvn:--settings"),
     /** The pom or directory to build */
     MAVEN_FILE(null, null, null, OptionType.PATH, Flags.NONE, "mvn:-f", "mvn:--file"),
     /** The root directory of the current multi module Maven project */


### PR DESCRIPTION
The local repo and maven settings are both used while resolving core extensions, which happens during daemon startup. Thus these two also need to be discriminating properties, as the core extensions themselves are discriminating.

Our concrete use case is that our extension's integration tests use an isolated repository which is deleted after the build, so we don't pile up garbage data on our CI agents. The lack of support for a custom local repository means we currently can't run the tests for our Maven extension against the Maven daemon.