### PR TITLE
Fix core export provider

### DIFF
--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
@@ -64,6 +64,7 @@ import org.apache.maven.exception.ExceptionSummary;
 import org.apache.maven.execution.*;
 import org.apache.maven.execution.scope.internal.MojoExecutionScopeModule;
 import org.apache.maven.extension.internal.CoreExports;
+import org.apache.maven.extension.internal.CoreExportsProvider;
 import org.apache.maven.extension.internal.CoreExtensionEntry;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.model.building.ModelProcessor;
@@ -518,6 +519,7 @@ public class DaemonMavenCli {
             protected void configure() {
                 bind(ILoggerFactory.class).toInstance(slf4jLoggerFactory);
                 bind(CoreExports.class).toInstance(exports);
+                bind(CoreExportsProvider.class).toInstance(new CoreExportsProvider(exports));
                 bind(ExtensionRealmCache.class).to(InvalidatingExtensionRealmCache.class);
                 bind(PluginArtifactsCache.class).to(InvalidatingPluginArtifactsCache.class);
                 bind(PluginRealmCache.class).to(InvalidatingPluginRealmCache.class);

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ExtensionWithApiTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ExtensionWithApiTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.mvndaemon.mvnd.it;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.mvndaemon.mvnd.assertj.TestClientOutput;
+import org.mvndaemon.mvnd.client.Client;
+import org.mvndaemon.mvnd.client.DaemonParameters;
+import org.mvndaemon.mvnd.junit.MvndNativeTest;
+
+@MvndNativeTest(projectDir = "src/test/projects/extension-with-api")
+public class ExtensionWithApiTest {
+
+    @Inject
+    Client client;
+
+    @Inject
+    DaemonParameters parameters;
+
+    @Test
+    void pluginCanAccessExtensionApi() throws InterruptedException {
+        install("extension");
+        install("plugin");
+        TestClientOutput o = new TestClientOutput();
+        client.execute(o, "org.mvndaemon.mvnd.test.extension.with.api:plugin:mojo")
+                .assertSuccess();
+        o.assertContainsMatchingSubsequence("Hello World!");
+    }
+
+    private void install(String project) throws InterruptedException {
+        TestClientOutput o = new TestClientOutput();
+        client.execute(o, "-f", project, "install").assertSuccess();
+    }
+}

--- a/integration-tests/src/test/projects/extension-with-api/.mvn/extensions.xml
+++ b/integration-tests/src/test/projects/extension-with-api/.mvn/extensions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extensions>
+    <extension>
+        <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+        <artifactId>extension</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </extension>
+</extensions>

--- a/integration-tests/src/test/projects/extension-with-api/.mvn/maven.config
+++ b/integration-tests/src/test/projects/extension-with-api/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10

--- a/integration-tests/src/test/projects/extension-with-api/extension/.mvn/maven.config
+++ b/integration-tests/src/test/projects/extension-with-api/extension/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10

--- a/integration-tests/src/test/projects/extension-with-api/extension/pom.xml
+++ b/integration-tests/src/test/projects/extension-with-api/extension/pom.xml
@@ -1,0 +1,71 @@
+<!--
+
+    Copyright 2019 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+    <artifactId>extension</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.sisu</groupId>
+            <artifactId>org.eclipse.sisu.inject</artifactId>
+            <version>0.3.5</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.6.3</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>0.3.5</version>
+                <executions>
+                    <execution>
+                        <id>generate-index</id>
+                        <goals>
+                            <goal>main-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/src/test/projects/extension-with-api/extension/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/extension/TheApi.java
+++ b/integration-tests/src/test/projects/extension-with-api/extension/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/extension/TheApi.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test.extension.with.api.extension;
+
+
+public interface TheApi {
+    void sayHello();
+}

--- a/integration-tests/src/test/projects/extension-with-api/extension/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/extension/TheImpl.java
+++ b/integration-tests/src/test/projects/extension-with-api/extension/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/extension/TheImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test.extension.with.api.extension;
+
+import org.apache.maven.eventspy.EventSpy;
+import org.apache.maven.eventspy.AbstractEventSpy;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.sisu.Typed;
+
+@Named
+@Typed({EventSpy.class, TheApi.class})
+@Singleton
+public class TheImpl extends AbstractEventSpy implements TheApi {
+    private boolean init;
+
+    @Override
+    public void init(Context context) throws Exception {
+        System.out.println("Api extension is initialized");
+        init = true;
+    }
+
+    @Override
+    public void sayHello() {
+        if (init) {
+            System.out.println("Hello World!");
+        } else {
+            throw new IllegalStateException("Not initialized");
+        }
+    }
+}

--- a/integration-tests/src/test/projects/extension-with-api/extension/src/main/resources/META-INF/maven/extension.xml
+++ b/integration-tests/src/test/projects/extension-with-api/extension/src/main/resources/META-INF/maven/extension.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<extension>
+    <exportedPackages>
+        <exportedPackage>org.mvndaemon.mvnd.test.extension.with.api.extension</exportedPackage>
+    </exportedPackages>
+    <exportedArtifacts>
+        <exportedArtifact>org.mvndaemon.mvnd.test.extension.with.api:extension</exportedArtifact>
+    </exportedArtifacts>
+</extension>

--- a/integration-tests/src/test/projects/extension-with-api/plugin/.mvn/maven.config
+++ b/integration-tests/src/test/projects/extension-with-api/plugin/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10

--- a/integration-tests/src/test/projects/extension-with-api/plugin/pom.xml
+++ b/integration-tests/src/test/projects/extension-with-api/plugin/pom.xml
@@ -1,0 +1,63 @@
+<!--
+
+    Copyright 2019 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+    <artifactId>plugin</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+            <artifactId>extension</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <!-- Not using provided scope here to test that the extension's exported artifacts
+            are correctly removed from plugin dependencies -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.6.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.6.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-tests/src/test/projects/extension-with-api/plugin/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/plugin/TheMojo.java
+++ b/integration-tests/src/test/projects/extension-with-api/plugin/src/main/java/org/mvndaemon/mvnd/test/extension/with/api/plugin/TheMojo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvndaemon.mvnd.test.extension.with.api.plugin;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import javax.inject.Inject;
+
+import org.mvndaemon.mvnd.test.extension.with.api.extension.TheApi;
+
+@Mojo( name = "mojo")
+public class TheMojo extends AbstractMojo {
+    @Inject
+    TheApi api;
+
+    public void execute() throws MojoExecutionException {
+        api.sayHello();
+    }
+}

--- a/integration-tests/src/test/projects/extension-with-api/pom.xml
+++ b/integration-tests/src/test/projects/extension-with-api/pom.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright 2019 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+    <artifactId>plugin-user</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.mvndaemon.mvnd.test.extension.with.api</groupId>
+                <artifactId>plugin</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Since https://github.com/apache/maven/pull/616, the default CoreExportProvider no longer uses the provided CoreExports, but instead tries (and fails) to discover them itself.

This change fixes that by providing our own custom instance of CoreExportProvider. This allows core extension to contribute exported artifacts and exported packages again, like it used to do before the Maven 4.x upgrade.