### PR TITLE
[0.10.x] Run client connection handler inside new thread, fixes #798

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-22.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
@@ -233,7 +233,16 @@ public class Server implements AutoCloseable, Runnable {
         try {
             while (true) {
                 try (SocketChannel socket = this.socket.accept()) {
-                    client(socket);
+                    try {
+                        // execute the client connection handling inside a new thread to guard against possible
+                        // ThreadLocal memory leaks
+                        // see https://github.com/apache/maven-mvnd/issues/798 for more details
+                        Thread handler = new Thread(() -> client(socket));
+                        handler.start();
+                        handler.join();
+                    } catch (Throwable t) {
+                        LOGGER.error("Error handling a client connection", t);
+                    }
                 }
             }
         } catch (Throwable t) {
@@ -264,7 +273,7 @@ public class Server implements AutoCloseable, Runnable {
                 updateState(DaemonState.Idle);
                 return;
             }
-            LOGGER.info("Request received: " + message);
+            LOGGER.info("Request received: {}", message);
             if (message instanceof BuildRequest) {
                 handle(connection, (BuildRequest) message);
             }


### PR DESCRIPTION
* similar fix is likely needed for master branch, possible older branches (but the issue is not manifesting in daemon 0.9.x so maybe we don't need to backport there)