### PR TITLE
[0.10.x] Publish the binaries produced by the Early Access job again

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -88,4 +88,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: mvnd-${{ env.OS }}
-          path: dist/target/mvnd-*.zip
+          path: dist/target/maven-mvnd-*.zip


### PR DESCRIPTION
Already fixed on master, cherry-picked from 5cd0f754d58ec213d19e5e95f40ac15ec4f36e05