### PR TITLE
Run client connection handler inside new thread, fixes #798 

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-22.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
* same as https://github.com/apache/maven-mvnd/pull/799 but for master branch
* I quickly tested this locally and master was suffering from the same thread leak issue as the 0.10.x. If we decided this is the solution, then it should be applied to master as well