### PR TITLE
Make the default (non-native) build work again

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -28,7 +28,25 @@ env:
   JAVA_VERSION: '17'
 
 jobs:
-  build:
+  default-build:
+    name: 'Default build (without Graal)'
+    if: startsWith(github.event.head_commit.message, '[release] Release ') != true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+
+      - name: 'Run default (non-native) build'
+        run: ./mvnw verify -Dmrm=false -B -ntp -e
+
+      - name: 'Upload daemon test logs'
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: daemon-test-logs-default-build
+          path: integration-tests/target/mvnd-tests/**/daemon*.log
+
+  native-build:
     name: 'Build with Graal on ${{ matrix.os }}'
     if: startsWith(github.event.head_commit.message, '[release] Release ') != true
     strategy:

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ExtensionWithApiNativeIT.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ExtensionWithApiNativeIT.java
@@ -27,7 +27,7 @@ import org.mvndaemon.mvnd.client.DaemonParameters;
 import org.mvndaemon.mvnd.junit.MvndNativeTest;
 
 @MvndNativeTest(projectDir = "src/test/projects/extension-with-api")
-public class ExtensionWithApiTest {
+public class ExtensionWithApiNativeIT {
 
     @Inject
     Client client;


### PR DESCRIPTION
* `mvn clean install` currently fails with
```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR] org.mvndaemon.mvnd.it.ExtensionWithApiTest.pluginCanAccessExtensionApi
[ERROR]   Run 1: ExtensionWithApiTest.pluginCanAccessExtensionApi » IllegalState mvnd executable does not exist: <...>/maven-mvnd/dist-m39/target/maven-1.0.0-m5-SNAPSHOT-mvnd-m39-linux-amd64/bin/mvnd
[ERROR]   Run 2: ExtensionWithApiTest.pluginCanAccessExtensionApi » IllegalState mvnd executable does not exist: <...>/maven-mvnd/dist-m39/target/maven-1.0.0-m5-SNAPSHOT-mvnd-m39-linux-amd64/bin/mvnd
[ERROR]   Run 3: ExtensionWithApiTest.pluginCanAccessExtensionApi » IllegalState mvnd executable does not exist: <...>/maven-mvnd/dist-m39/target/maven-1.0.0-m5-SNAPSHOT-mvnd-m39-linux-amd64/bin/mvnd
[ERROR]   Run 4: ExtensionWithApiTest.pluginCanAccessExtensionApi » IllegalState mvnd executable does not exist: <...>/maven-mvnd/dist-m39/target/maven-1.0.0-m5-SNAPSHOT-mvnd-m39-linux-amd64/bin/mvnd
[ERROR]   Run 5: ExtensionWithApiTest.pluginCanAccessExtensionApi » IllegalState mvnd executable does not exist: <...>/maven-mvnd/dist-m39/target/maven-1.0.0-m5-SNAPSHOT-mvnd-m39-linux-amd64/bin/mvnd
```

 * the renamed test is supposed to use the native binary, but it was being picked up by surefire, because of its name. For non-native builds (e.g. without -Pnative) the test would fail as the native binary does not exist

* I also tried to create a non-native test (following the same pattern as with the other tests), but that actually fails with a somewhat cryptic guice error. I am not sure if this test is supposed to work in non-native mode. If so, some additional fixes would be needed.

<details>
  <summary>Error details</summary>

```
ExecutionFailure{projectId='plugin-user', halted=true, exception='org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo (default-cli) on project plugin-user: Execution default-cli of goal org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo failed: Unable to load the mojo 'mojo' (or one of its required components) from the plugin 'org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT''}
ProjectLogMessage{projectId='plugin-user', message='[DEBUG] FAILURE build of project org.mvndaemon.mvnd.test.extension.with.api:plugin-user'}
ProjectLogMessage{projectId='plugin-user', message='[DEBUG] Builder state: blocked=0 finished=1 ready-or-running=0 '}
ProjectLogMessage{projectId='plugin-user', message='[INFO] ------------------------------------------------------------------------'}
ProjectLogMessage{projectId='plugin-user', message='[INFO] BUILD FAILURE'}
ProjectLogMessage{projectId='plugin-user', message='[INFO] ------------------------------------------------------------------------'}
ProjectLogMessage{projectId='plugin-user', message='[INFO] Total time:  0.035 s (Wall Clock)'}
ProjectLogMessage{projectId='plugin-user', message='[INFO] Finished at: 2023-03-10T17:02:07+01:00'}
ProjectLogMessage{projectId='plugin-user', message='[INFO] ------------------------------------------------------------------------'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Failed to execute goal org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo (default-cli) on project plugin-user: Execution default-cli of goal org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo failed: Unable to load the mojo 'mojo' (or one of its required components) from the plugin 'org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT': com.google.inject.ProvisionException: Unable to provision, see the following errors:'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] 1) [Guice/NullInjectedIntoNonNullable]: null returned by binding at LocatorWiring'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]  but TheMojo.api(TheMojo.java:28) is not @Nullable'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   at LocatorWiring'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   at TheMojo.api(TheMojo.java:28)'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]       \_ for field api'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   while locating TheMojo'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   at ClassRealm[plugin>org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT, parent: URLClassLoader@c51f883]'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]       \_ installed by: WireModule -> PlexusBindingModule'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   while locating Mojo annotated with @Named("org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo")'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Learn more:'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   https://github.com/google/guice/wiki/NULL_INJECTED_INTO_NON_NULLABLE'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] 1 error'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] ======================'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Full classname legend:'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] ======================'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] LocatorWiring:       "org.eclipse.sisu.wire.LocatorWiring"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Mojo:                "org.apache.maven.plugin.Mojo"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Named:               "com.google.inject.name.Named"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] PlexusBindingModule: "org.eclipse.sisu.plexus.PlexusBindingModule"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] TheMojo:             "org.mvndaemon.mvnd.test.extension.with.api.plugin.TheMojo"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] URLClassLoader:      "java.net.URLClassLoader"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] WireModule:          "org.eclipse.sisu.wire.WireModule"'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] ========================'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] End of classname legend:'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] ========================'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]       role: org.apache.maven.plugin.Mojo'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR]   roleHint: org.mvndaemon.mvnd.test.extension.with.api:plugin:0.0.1-SNAPSHOT:mojo'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] -> [Help 1]'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] Re-run Maven using the -X switch to enable full debug logging.'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] '}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] For more information about the errors and possible solutions, please read the following articles:'}
ProjectLogMessage{projectId='plugin-user', message='[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException'}
```
</details>

