### PR TITLE
Build on ubuntu 20.04

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -31,7 +31,7 @@ jobs:
   default-build:
     name: 'Default build (without Graal)'
     if: startsWith(github.event.head_commit.message, '[release] Release ') != true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-18.04, macOS-10.15, windows-2019 ]
+        os: [ ubuntu-20.04, macOS-10.15, windows-2019 ]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   source:
     name: 'Build source distributions'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v2
@@ -121,7 +121,7 @@ jobs:
             target/maven-mvnd-*.tar.gz
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [build, source]
 
     steps:


### PR DESCRIPTION
* fixes #812 
* building on ubuntu:22.04 produces binaries which require too recent glibc
   version (2.32+) and that means the binary no longer works on
   older ubuntu versions, like 20.04 and 18.04.

 * building on ubuntu:20.04 fixes the problem and the binary again works
   on ubuntu 18.04 and 20.04

 * also bumped the version in the release workflow which got forgotten