### PR TITLE
Prompter prompt should not prepend the projectId when there's only one project, fixes #816

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
@@ -350,7 +350,10 @@ public class TerminalOutput implements ClientOutput {
                 readInput.writeLock().lock();
                 try {
                     clearDisplay();
-                    terminal.writer().printf("[%s] %s", prompt.getProjectId(), prompt.getMessage());
+                    String msg = (maxThreads > 1)
+                            ? String.format("[%s] %s", prompt.getProjectId(), prompt.getMessage())
+                            : prompt.getMessage();
+                    terminal.writer().print(msg);
                     terminal.flush();
                     StringBuilder sb = new StringBuilder();
                     while (true) {

--- a/dist/src/main/distro/mvn/conf/logging/logback-daemon.xml
+++ b/dist/src/main/distro/mvn/conf/logging/logback-daemon.xml
@@ -36,6 +36,10 @@
     <appender-ref ref="DAEMON" />
   </logger>
 
+  <logger name="org.mvndaemon.mvnd.interactivity" level="DEBUG" additivity="false">
+    <appender-ref ref="DAEMON" />
+  </logger>
+
   <logger name="Sisu" level="INFO" />
 
   <!-- suppress annoying @threadSafe and checksum failure warning messages -->


### PR DESCRIPTION
Also make sure the daemon prompter log only goes to the daemon log
