### PR TITLE
Use full terminal width in CLI with Maven 4

### DIFF
--- a/daemon-m40/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
+++ b/daemon-m40/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
@@ -207,6 +207,8 @@ public class DaemonMavenCli implements DaemonCli {
             throws Exception {
         this.buildEventListener = buildEventListener;
         try {
+            MessageUtils.systemInstall();
+            MessageUtils.registerShutdownHook();
             CliRequest req = new CliRequest(null, null);
             req.args = arguments.toArray(new String[0]);
             req.workingDirectory = new File(workingDirectory).getCanonicalPath();
@@ -214,6 +216,7 @@ public class DaemonMavenCli implements DaemonCli {
             return doMain(req, clientEnv);
         } finally {
             this.buildEventListener = BuildEventListener.dummy();
+            MessageUtils.systemUninstall();
         }
     }
 

--- a/daemon/src/main/java/org/apache/maven/cli/MvndHelpFormatter.java
+++ b/daemon/src/main/java/org/apache/maven/cli/MvndHelpFormatter.java
@@ -30,6 +30,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.maven.cli.jansi.MessageUtils;
+import org.fusesource.jansi.AnsiConsole;
 import org.mvndaemon.mvnd.common.Environment;
 import org.mvndaemon.mvnd.common.OptionType;
 
@@ -149,13 +151,9 @@ public class MvndHelpFormatter {
     }
 
     private static int getTerminalWidth() {
-        int terminalWidth;
-        try {
-            terminalWidth = Environment.MVND_TERMINAL_WIDTH.asInt();
-        } catch (Exception e) {
-            terminalWidth = 80;
-        }
-        return terminalWidth;
+        System.out.println(MessageUtils.getTerminalWidth());
+        System.out.println(AnsiConsole.isInstalled());
+        return MessageUtils.getTerminalWidth();
     }
 
     private static void indentedLine(StringBuilder stringBuilder, int terminalWidth, String text, String indent) {
@@ -208,5 +206,16 @@ public class MvndHelpFormatter {
             stringBuilder.append(' ');
         }
         return stringBuilder;
+    }
+
+    static {
+        boolean jansi = true;
+
+        try {
+            Class.forName("org.fusesource.jansi.Ansi");
+        } catch (ClassNotFoundException var2) {
+            jansi = false;
+        }
+        System.out.println(jansi);
     }
 }


### PR DESCRIPTION
I am trying to solve the following issue: #870 

As far as I can determine this code (Also contains some test code which can be removed later) should work for using the full terminal width in maven-mvnd, comparing it with the code in the maven repository for using the full terminal width in maven 4. 

However, the terminal width is always -1.

Can anyone shed some light on as to why this is happening? Maybe @ppalaga or @gnodet ?