### PR TITLE
Update to parent POM 42

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,30 @@
 #
-# Copyright 2022 the original author or authors.
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 version: 2
 updates:
+
   - package-ecosystem: maven
-    directory: '/'
+    directory: "/"
     schedule:
       interval: daily
-    # see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit
-    # open-pull-requests-limit: 10
-    versioning-strategy: increase
+      time: '04:00'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,11 @@
   <packaging>jar</packaging>
   <name>Maven Daemon - Common</name>
 
+  <properties>
+    <!-- If using release, sun.misc is not reachable (see SignalHelper) -->
+    <maven.compiler.release />
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/daemon-m39/pom.xml
+++ b/daemon-m39/pom.xml
@@ -47,4 +47,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/daemon-m40/pom.xml
+++ b/daemon-m40/pom.xml
@@ -47,4 +47,13 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -30,6 +30,11 @@
   <packaging>jar</packaging>
   <name>Maven Daemon - Daemon</name>
 
+  <properties>
+    <!-- If using release, sun.misc is not reachable (see SignalHelper) -->
+    <maven.compiler.release />
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.daemon</groupId>
@@ -104,6 +109,10 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -58,6 +58,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.6.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>40</version>
+    <version>42</version>
     <relativePath />
   </parent>
 
@@ -68,8 +68,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
     <maven-dist.required.jdk>8</maven-dist.required.jdk>
     <project.build.outputTimestamp>2023-10-26T05:45:19Z</project.build.outputTimestamp>
     <trimStackTrace>false</trimStackTrace>
@@ -87,7 +87,6 @@
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.0</jansi.version>
     <jline.version>3.24.0</jline.version>
-    <junit.jupiter.version>5.9.2</junit.jupiter.version>
     <maven.version>4.0.0-alpha-8</maven.version>
     <maven3.version>3.9.6</maven3.version>
     <maven4.version>${maven.version}</maven4.version>
@@ -152,14 +151,6 @@
         <groupId>org.graalvm.nativeimage</groupId>
         <artifactId>svm</artifactId>
         <version>${graalvm.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit.jupiter.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Changes:
* parent POM 42
* unset release where needed (makes com.sun pkg unreachable)
* explicitly index as parent disables "implicit" AP
* remove redundtant stuff
* update dependabot to take care of workflow as well (as mvnd uses own)