### PR TITLE
Align mvnd m39 with Maven 3.9.x re config interpolation

### DIFF
--- a/integration-tests/src/test/projects/maven-conf/.mvn/maven.config
+++ b/integration-tests/src/test/projects/maven-conf/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dsomething=${session.rootDirectory}


### PR DESCRIPTION
Port Maven 3.9.6 config and new properties (session.root/top) interpolation into Daemon m39.

The IT got this property as it triggers exception (failure) if mvn39 could not "discover" top directory.

Fixes #910