### PR TITLE
Maven 4 beta-2

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,4 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.8/apache-maven-3.8.8-bin.zip
+wrapperVersion=3.3.1
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
@@ -1141,6 +1141,15 @@ public class DaemonMavenCli implements DaemonCli {
         request.setMakeBehavior(determineMakeBehavior(commandLine));
         request.setCacheNotFound(true);
         request.setCacheTransferError(false);
+        boolean strictArtifactDescriptorPolicy = commandLine.hasOption(CLIManager.STRICT_ARTIFACT_DESCRIPTOR_POLICY)
+                && Boolean.parseBoolean(commandLine.getOptionValue(CLIManager.STRICT_ARTIFACT_DESCRIPTOR_POLICY));
+        if (strictArtifactDescriptorPolicy) {
+            request.setIgnoreMissingArtifactDescriptor(false);
+            request.setIgnoreInvalidArtifactDescriptor(false);
+        } else {
+            request.setIgnoreMissingArtifactDescriptor(true);
+            request.setIgnoreInvalidArtifactDescriptor(true);
+        }
         request.setIgnoreTransitiveRepositories(commandLine.hasOption(CLIManager.IGNORE_TRANSITIVE_REPOSITORIES));
 
         performProjectActivation(commandLine, request.getProjectActivation());

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenCli.java
@@ -1141,6 +1141,7 @@ public class DaemonMavenCli implements DaemonCli {
         request.setMakeBehavior(determineMakeBehavior(commandLine));
         request.setCacheNotFound(true);
         request.setCacheTransferError(false);
+        request.setIgnoreTransitiveRepositories(commandLine.hasOption(CLIManager.IGNORE_TRANSITIVE_REPOSITORIES));
 
         performProjectActivation(commandLine, request.getProjectActivation());
         performProfileActivation(commandLine, request.getProfileActivation());

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -73,7 +73,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.1</version>
         <executions>
           <execution>
             <id>extract</id>
@@ -98,7 +97,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>add-unpacked-source-dir</id>

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.0
+# Apache Maven Wrapper startup batch script, version 3.3.1
 #
 # Optional ENV vars
 # -----------------
@@ -199,7 +199,7 @@ elif set_java_home; then
 	  public static void main( String[] args ) throws Exception
 	  {
 	    setDefault( new Downloader() );
-	    java.nio.file.Files.copy( new java.net.URL( args[0] ).openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
 	  }
 	}
 	END

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.0
+@REM Apache Maven Wrapper startup batch script, version 3.3.1
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
     <commons-compress.version>1.26.1</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>22.3.1</graalvm.version>
-    <graalvm.plugin.version>0.10.1</graalvm.plugin.version>
+    <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
     <groovy.version>4.0.21</groovy.version>
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.1</jline.version>
-    <maven.version>4.0.0-beta-1-SNAPSHOT</maven.version>
+    <maven.version>4.0.0-beta-2</maven.version>
     <!-- Keep in sync with Maven -->
     <maven.resolver.version>2.0.0-alpha-11</maven.resolver.version>
     <slf4j.version>2.0.11</slf4j.version>
@@ -96,7 +96,7 @@
     <groovy-maven-plugin.version>3.0.2</groovy-maven-plugin.version>
     <mrm.version>1.6.0</mrm.version>
     <junit-platform-launcher.version>1.3.2</junit-platform-launcher.version>
-    <takari-provisio.version>1.0.24</takari-provisio.version>
+    <takari-provisio.version>1.0.25</takari-provisio.version>
 
     <javassist.version>3.29.2-GA</javassist.version>
     <xstream.version>1.4.20</xstream.version>
@@ -336,6 +336,21 @@
     </dependencies>
   </dependencyManagement>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>maven-2117</id>
+      <url>https://repository.apache.org/content/repositories/maven-2117/</url>
+    </repository>
+  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -433,12 +448,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-wrapper-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -466,7 +481,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.5.4</version>
+                  <version>3.6.3</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17,)</version>


### PR DESCRIPTION
And fix the build w/ smaller cleanups, plugin updates and backport of `-itr`, `-sadp`.

Changes:
* Maven 4 beta-2 (staged, on vote)
* Maven Wrapper 3.3.1 + script updates
* maven-plugin-tools 3.13.0
* buildhelper-maven-plugin 3.6.0
* graalvm plugin 0.10.2
* provisio 1.0.25
* exec-maven-plugin 3.3.0
* backport `-itr` and `-sadp` (Maven CLI)