### PR TITLE
Update deps

### DIFF
--- a/build-plugin/pom.xml
+++ b/build-plugin/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
 
-    <roaster.version>2.29.0.Final</roaster.version>
+    <roaster.version>2.28.0.Final</roaster.version>
     <maven.version>3.9.6</maven.version>
     <maven.plugin-tools.version>3.13.0</maven.plugin-tools.version>
   </properties>

--- a/build-plugin/pom.xml
+++ b/build-plugin/pom.xml
@@ -34,7 +34,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
 
-    <roaster.version>2.28.0.Final</roaster.version>
+    <roaster.version>2.29.0.Final</roaster.version>
     <maven.version>3.9.6</maven.version>
     <maven.plugin-tools.version>3.13.0</maven.plugin-tools.version>
   </properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -41,7 +41,7 @@
             org/junit/jupiter/junit-jupiter/${junit.jupiter.version}
             org/junit/jupiter/junit-jupiter-api/${junit.jupiter.version}</preinstall.artifacts>
 
-    <testcontainers.version>1.19.7</testcontainers.version>
+    <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 
   <dependencies>

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -29,7 +29,7 @@
   <name>Maven Daemon - Native Library</name>
 
   <properties>
-    <picocli.version>4.5.2</picocli.version>
+    <picocli.version>4.7.6</picocli.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <groovy.version>4.0.21</groovy.version>
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
-    <jline.version>3.25.1</jline.version>
+    <jline.version>3.26.1</jline.version>
     <maven.version>3.9.7</maven.version>
     <!-- Keep in sync with Maven -->
     <maven.resolver.version>1.9.20</maven.resolver.version>
@@ -97,7 +97,7 @@
     <junit-platform-launcher.version>1.3.2</junit-platform-launcher.version>
     <takari-provisio.version>1.0.25</takari-provisio.version>
 
-    <javassist.version>3.29.2-GA</javassist.version>
+    <javassist.version>3.30.2-GA</javassist.version>
     <xstream.version>1.4.20</xstream.version>
     <plexus-interactivity-api.version>1.3</plexus-interactivity-api.version>
     <takari-smart-builder.version>0.6.5</takari-smart-builder.version>


### PR DESCRIPTION
(same as on master, align with master)

Changes:
* ~roaster 2.29.0.Final~ (bytecode is banned by enforcer, is newer than allowed)
* testcontainers 1.19.8
* picocli 4.7.6
* jline 3.26.1
* javassist 3.30.2-GA