### PR TITLE
[1.x] Pre-release tidy-up

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.1
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip

--- a/build-plugin/pom.xml
+++ b/build-plugin/pom.xml
@@ -33,27 +33,7 @@
   <properties>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
-
-    <roaster.version>2.28.0.Final</roaster.version>
-    <maven.version>3.9.6</maven.version>
-    <maven.plugin-tools.version>3.13.0</maven.plugin-tools.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-plugin-api</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven.plugin-tools.version}</version>
-      </dependency>
-
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -70,22 +50,10 @@
     <dependency>
       <groupId>org.jboss.forge.roaster</groupId>
       <artifactId>roaster-jdt</artifactId>
-      <version>${roaster.version}</version>
     </dependency>
-
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>${maven.plugin-tools.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.daemon</groupId>
         <artifactId>mvnd-build-maven-plugin</artifactId>
-        <version>${project.version}</version>
         <executions>
           <execution>
             <goals>
@@ -101,6 +100,7 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <executions>
               <execution>
@@ -145,6 +145,7 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <executions>
               <execution>

--- a/common/src/main/java/org/mvndaemon/mvnd/common/InterpolationHelper.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/InterpolationHelper.java
@@ -75,7 +75,7 @@ public class InterpolationHelper {
      * <p>
      * This method performs property variable substitution on the
      * specified value. If the specified value contains the syntax
-     * <tt>${&lt;prop-name&gt;}</tt>, where <tt>&lt;prop-name&gt;</tt>
+     * {@code ${prop-name}}, where {@code prop-name}
      * refers to either a configuration property or a system property,
      * then the corresponding property value is substituted for the variable
      * placeholder. Multiple variable placeholders may exist in the

--- a/common/src/main/java/org/mvndaemon/mvnd/common/OsUtils.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/OsUtils.java
@@ -138,7 +138,7 @@ public class OsUtils {
 
     /**
      * A simple wrapper over {@link Process} that manages its destroying and offers Java 8-like
-     * {@link #waitFor(long, TimeUnit, String[])} with timeout.
+     * {@link #waitFor(long)} with timeout.
      */
     public static class CommandProcess implements AutoCloseable {
         public static final int TIMEOUT_EXIT_CODE = Integer.MIN_VALUE + 42;

--- a/daemon/pom.xml
+++ b/daemon/pom.xml
@@ -94,7 +94,6 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
-      <version>${sisu.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -40,8 +40,6 @@
             org/junit/platform/junit-platform-commons/${junit-platform-launcher.version}
             org/junit/jupiter/junit-jupiter/${junit.jupiter.version}
             org/junit/jupiter/junit-jupiter-api/${junit.jupiter.version}</preinstall.artifacts>
-
-    <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 
   <dependencies>
@@ -85,13 +83,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -64,7 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.1</version>
         <executions>
           <execution>
             <id>extract</id>
@@ -90,7 +89,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.0</version>
         <executions>
           <execution>
             <id>add-unpacked-source-dir</id>

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.1
+# Apache Maven Wrapper startup batch script, version 3.3.2
 #
 # Optional ENV vars
 # -----------------
@@ -97,11 +97,19 @@ die() {
   exit 1
 }
 
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
-  distributionUrl) distributionUrl="${value-}" ;;
-  distributionSha256Sum) distributionSha256Sum="${value-}" ;;
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
 done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
 [ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
@@ -131,7 +139,8 @@ esac
 distributionUrlName="${distributionUrl##*/}"
 distributionUrlNameMain="${distributionUrlName%.*}"
 distributionUrlNameMain="${distributionUrlNameMain%-bin}"
-MAVEN_HOME="$HOME/.m2/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 
 exec_maven() {
   unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.1
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -79,6 +79,9 @@ if ($env:MVNW_REPOURL) {
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
 $MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
 $MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -28,10 +28,6 @@
   <packaging>jar</packaging>
   <name>Maven Daemon - Native Library</name>
 
-  <properties>
-    <picocli.version>4.7.6</picocli.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -46,7 +42,6 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli-codegen</artifactId>
-      <version>${picocli.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
 
     <!-- dependency versions a..z -->
     <apiguardian-api.version>1.0.0</apiguardian-api.version>
-    <assertj.version>3.25.3</assertj.version>
-    <commons-compress.version>1.26.1</commons-compress.version>
+    <assertj.version>3.26.0</assertj.version>
+    <commons-compress.version>1.26.2</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>22.3.1</graalvm.version>
     <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
@@ -84,11 +84,11 @@
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.1</jline.version>
-    <maven.version>3.9.7</maven.version>
+    <maven.version>3.9.8-20240612.175612-19</maven.version>
     <!-- Keep in sync with Maven -->
     <maven.resolver.version>1.9.20</maven.resolver.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <sisu.version>0.9.0.M2</sisu.version>
+    <sisu.version>0.9.0.M3</sisu.version>
 
     <!-- plugin versions a..z -->
     <buildnumber-maven-plugin.version>3.2.0</buildnumber-maven-plugin.version>
@@ -97,10 +97,14 @@
     <junit-platform-launcher.version>1.3.2</junit-platform-launcher.version>
     <takari-provisio.version>1.0.25</takari-provisio.version>
 
+    <picocli.version>4.7.6</picocli.version>
+    <roaster.version>2.28.0.Final</roaster.version>
+    <maven.plugin-tools.version>3.13.1</maven.plugin-tools.version>
     <javassist.version>3.30.2-GA</javassist.version>
     <xstream.version>1.4.20</xstream.version>
     <plexus-interactivity-api.version>1.3</plexus-interactivity-api.version>
-    <takari-smart-builder.version>0.6.5</takari-smart-builder.version>
+    <takari-smart-builder.version>0.6.6</takari-smart-builder.version>
+    <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 
   <dependencyManagement>
@@ -164,10 +168,20 @@
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+        <version>${maven.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
         <artifactId>apache-maven</artifactId>
         <version>${maven.version}</version>
         <classifier>bin</classifier>
         <type>tar.gz</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.plugin-tools</groupId>
+        <artifactId>maven-plugin-annotations</artifactId>
+        <version>${maven.plugin-tools.version}</version>
       </dependency>
 
       <dependency>
@@ -279,6 +293,12 @@
       </dependency>
 
       <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli-codegen</artifactId>
+        <version>${picocli.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
@@ -292,6 +312,12 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.forge.roaster</groupId>
+        <artifactId>roaster-jdt</artifactId>
+        <version>${roaster.version}</version>
       </dependency>
 
       <dependency>
@@ -316,12 +342,28 @@
         <artifactId>takari-smart-builder</artifactId>
         <version>${takari-smart-builder.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${testcontainers.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.daemon</groupId>
+          <artifactId>mvnd-build-maven-plugin</artifactId>
+          <version>${project.version}</version>
+        </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
@@ -398,6 +440,26 @@
           <artifactId>native-maven-plugin</artifactId>
           <version>${graalvm.plugin.version}</version>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.7.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.7.0</version>
+          <configuration>
+            <release>8</release>
+            <detectJavaApiLink>false</detectJavaApiLink>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${maven.plugin-tools.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
@@ -415,7 +477,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-wrapper-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.6.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${sisu.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.plexus</artifactId>
+        <version>${sisu.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.jline</groupId>


### PR DESCRIPTION
Changes:
* no source changes
* (build) expel all versions from child modules: they must be all top level depMgmt or pluginMgmt
* (build) Top POM contains GAVs while child modules GA+scope. This tremendously simplifies maintenance.
* (javadoc) fix Javadoc errors

Updates:
* use latest Maven 3.9.8-SNAPSHOT (TS locked version, controlled deploy by me)
* AssertJ 3.26.0
* Takari Smart Builder 0.6.6
* Sisu 0.9.0.M3
* maven wrapper 3.3.2 w/ scripts

This brings mvnd-1.x in "releasable" state (once Maven 3.9.8 is out).