### PR TITLE
Release binaries: linux amd64, macos amd64, macos aarch64, windows amd64

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -69,10 +69,22 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
-          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          if [[ $ARCH == 'x64' ]]
+          then
+            echo "ARCH=amd64" >> $GITHUB_ENV
+          elif [[ $ARCH == 'arm64' ]]
+          then
+            echo "ARCH=aarch64" >> $GITHUB_ENV
+          else
+            echo "ARCH=$ARCH" >> $GITHUB_ENV
+          fi
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
+          if [[ $OS == 'macos' ]]
+          then
+            echo "OS=darwin" >> $GITHUB_ENV
+          else
+            echo "OS=$OS" >> $GITHUB_ENV
+          fi
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up Graal'

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -31,7 +31,7 @@ jobs:
   default-build:
     name: 'Default build (without Graal)'
     if: startsWith(github.event.head_commit.message, '[release] Release ') != true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4
@@ -69,7 +69,8 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
           [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -68,9 +68,10 @@ jobs:
       - name: 'Set vars'
         shell: bash
         run: |
+          ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'ubuntu' ]] && echo "OS=linux" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
-          [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
+          echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up Graal'
@@ -121,11 +122,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: daemon-test-logs-${{ env.OS }}
+          name: daemon-test-logs-${{ env.OS }}-${{ env.ARCH }}
           path: integration-tests/target/mvnd-tests/**/daemon*.log
 
       - name: 'Upload artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: mvnd-${{ env.OS }}
+          name: mvnd-${{ env.OS }}-${{ env.ARCH }}
           path: dist/target/maven-mvnd-*.zip

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -42,7 +42,7 @@ jobs:
           distribution: 'temurin'
 
       - name: 'Run default (non-native) build'
-        run: ./mvnw verify -Dmrm=false -V -B -ntp -e
+        run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
       - name: 'Upload daemon test logs'
         if: always()
@@ -71,7 +71,7 @@ jobs:
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
           echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          echo "OS=$OS" >> $GITHUB_ENV
+          [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up Graal'
@@ -107,7 +107,7 @@ jobs:
           objcopy --redefine-syms=client/src/main/resources/glibc/glibc.redef client/target/graalvm-libs-for-glibc-2.12/Scrt1.o 2>/dev/null
 
       - name: 'Build native distribution'
-        run: ./mvnw verify -Pnative -Dmrm=false -V -B -ntp -e
+        run: ./mvnw verify -Pnative -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
       - name: 'Verify native binary for only requiring glibc 2.12'
         if: ${{ env.OS == 'linux' }}

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -57,7 +57,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # binaries wanted: linux amd64, mac intel, mac M1, windows x86
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,10 +46,22 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
-          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          if [[ $ARCH == 'x64' ]]
+          then
+            echo "ARCH=amd64" >> $GITHUB_ENV
+          elif [[ $ARCH == 'arm64' ]]
+          then
+            echo "ARCH=aarch64" >> $GITHUB_ENV
+          else
+            echo "ARCH=$ARCH" >> $GITHUB_ENV
+          fi
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
+          if [[ $OS == 'macos' ]]
+          then
+            echo "OS=darwin" >> $GITHUB_ENV
+          else
+            echo "OS=$OS" >> $GITHUB_ENV
+          fi
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up Graal'
@@ -115,10 +127,22 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
-          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          if [[ $ARCH == 'x64' ]]
+          then
+            echo "ARCH=amd64" >> $GITHUB_ENV
+          elif [[ $ARCH == 'arm64' ]]
+          then
+            echo "ARCH=aarch64" >> $GITHUB_ENV
+          else
+            echo "ARCH=$ARCH" >> $GITHUB_ENV
+          fi
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
+          if [[ $OS == 'macos' ]]
+          then
+            echo "OS=darwin" >> $GITHUB_ENV
+          else
+            echo "OS=$OS" >> $GITHUB_ENV
+          fi
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up Graal'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # binaries wanted: linux amd64, mac intel, mac M1, windows x86
         os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
     runs-on: ${{ matrix.os }}
 
@@ -44,8 +45,9 @@ jobs:
       - name: 'Set vars'
         shell: bash
         run: |
+          ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'ubuntu' ]] && echo "OS=linux" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
@@ -111,8 +113,9 @@ jobs:
       - name: 'Set vars'
         shell: bash
         run: |
+          ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
+          echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
-          [[ $OS == 'ubuntu' ]] && echo "OS=linux" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
@@ -158,8 +161,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-${{ runner.arch }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-m2
 
       - name: ls -R
         run: ls -R
@@ -237,6 +240,26 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-amd64.tar.gz
           asset_name: maven-mvnd-${{ env.VERSION }}-darwin-amd64.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: Deploy maven-mvnd-darwin-arm64.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-arm64.zip
+          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-arm64.zip
+          asset_content_type: application/zip
+
+      - name: Deploy maven-mvnd-darwin-arm64.tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-arm64.tar.gz
+          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-arm64.tar.gz
           asset_content_type: application/x-gzip
 
       - name: Deploy maven-mvnd-windows-amd64.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,8 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
           [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
@@ -105,7 +106,7 @@ jobs:
 
   source:
     name: 'Build source distributions'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
@@ -114,7 +115,8 @@ jobs:
         shell: bash
         run: |
           ARCH=$(echo '${{ runner.arch }}' | awk '{print tolower($0)}')
-          echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'x64' ]] && echo "ARCH=amd64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
+          [[ $ARCH == 'arm64' ]] && echo "ARCH=aarch64" >> $GITHUB_ENV || echo "ARCH=$ARCH" >> $GITHUB_ENV
           OS=$(echo '${{ runner.os }}' | awk '{print tolower($0)}')
           [[ $OS == 'macos' ]] && echo "OS=darwin" >> $GITHUB_ENV || echo "OS=$OS" >> $GITHUB_ENV
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
@@ -139,7 +141,7 @@ jobs:
             target/maven-mvnd-*.tar.gz
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [build, source]
 
     steps:
@@ -242,24 +244,24 @@ jobs:
           asset_name: maven-mvnd-${{ env.VERSION }}-darwin-amd64.tar.gz
           asset_content_type: application/x-gzip
 
-      - name: Deploy maven-mvnd-darwin-arm64.zip
+      - name: Deploy maven-mvnd-darwin-aarch64.zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-arm64.zip
-          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-arm64.zip
+          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-aarch64.zip
+          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-aarch64.zip
           asset_content_type: application/zip
 
-      - name: Deploy maven-mvnd-darwin-arm64.tar.gz
+      - name: Deploy maven-mvnd-darwin-aarch.tar.gz
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-arm64.tar.gz
-          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-arm64.tar.gz
+          asset_path: artifacts/dist/target/maven-mvnd-${{ env.VERSION }}-darwin-aarch64.tar.gz
+          asset_name: maven-mvnd-${{ env.VERSION }}-darwin-aarch64.tar.gz
           asset_content_type: application/x-gzip
 
       - name: Deploy maven-mvnd-windows-amd64.zip

--- a/.mvn/release-settings.xml
+++ b/.mvn/release-settings.xml
@@ -7,7 +7,7 @@
             <repositories>
                 <repository>
                     <id>maven-staging-1</id>
-                    <url>https://repository.apache.org/content/repositories/maven-1859/</url>
+                    <url>https://repository.apache.org/content/repositories/maven-2146/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.1</jline.version>
-    <maven.version>3.9.8-20240612.175612-19</maven.version>
+    <maven.version>3.9.8</maven.version>
     <!-- Keep in sync with Maven -->
     <maven.resolver.version>1.9.20</maven.resolver.version>
     <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
GH Action and related changes to finally cover all targeted OS/platforms with native binary.

Changes:
* no source change
* POM change: using released Maven 3.9.8 (and added access to staged Maven 3.9.8)
* Provide 4 plaf binaries: linux amd64, windows amd64, mac amd64 and mac aarch64
* adopt GH workflows for these changes (using "OS" alone is not enough)
* adopt generally GraalVM naming and use them consecutively