### PR TITLE
Fix deprecation warning about JAnsi Terminal

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -98,6 +98,7 @@
                 <enforceBytecodeVersion>
                   <maxJdkVersion>${maven.compiler.release}</maxJdkVersion>
                   <excludes>
+                    <exclude>org.jline:jline-terminal-ffm</exclude>
                     <exclude>org.graalvm.nativeimage:svm</exclude>
                   </excludes>
                 </enforceBytecodeVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -49,10 +49,6 @@
       <groupId>org.jline</groupId>
       <artifactId>jline-terminal-ffm</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -43,7 +43,15 @@
     </dependency>
     <dependency>
       <groupId>org.jline</groupId>
-      <artifactId>jline-terminal-jansi</artifactId>
+      <artifactId>jline-terminal-jni</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-ffm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
     </dependency>
 
     <dependency>

--- a/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
@@ -498,6 +498,10 @@ public class TerminalOutput implements ClientOutput {
         return terminal.getWidth();
     }
 
+    public Terminal getTerminal() {
+        return terminal;
+    }
+
     void readInputLoop() {
         try {
             while (!closing) {

--- a/dist/src/main/provisio/maven-distro.xml
+++ b/dist/src/main/provisio/maven-distro.xml
@@ -61,7 +61,10 @@
         <artifact id="org.jline:jline-terminal">
             <exclusion id="*:*"/>
         </artifact>
-        <artifact id="org.jline:jline-terminal-jansi">
+        <artifact id="org.jline:jline-terminal-ffm">
+            <exclusion id="*:*"/>
+        </artifact>
+        <artifact id="org.jline:jline-terminal-jni">
             <exclusion id="*:*"/>
         </artifact>
     </artifactSet>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
     <groovy.version>4.0.21</groovy.version>
     <jakarta.inject.version>1.0</jakarta.inject.version>
-    <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.1</jline.version>
     <maven.version>3.9.8</maven.version>
     <!-- Keep in sync with Maven -->
@@ -295,11 +294,6 @@
         <groupId>org.jline</groupId>
         <artifactId>jline-terminal-ffm</artifactId>
         <version>${jline.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.fusesource.jansi</groupId>
-        <artifactId>jansi</artifactId>
-        <version>${jansi.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,12 @@
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>
-        <artifactId>jline-terminal-jansi</artifactId>
+        <artifactId>jline-terminal-jni</artifactId>
+        <version>${jline.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline-terminal-ffm</artifactId>
         <version>${jline.version}</version>
       </dependency>
       <dependency>
@@ -523,6 +528,23 @@
                 <requireMavenVersion>
                   <version>3.5.4</version>
                 </requireMavenVersion>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                  <excludes>
+                    <exclude>org.jline:jline-terminal-ffm</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
               </rules>
               <fail>true</fail>
             </configuration>


### PR DESCRIPTION
And use JNI (and FFM) instead.

Changes:
* use DefaultClient from master (thanks @gnodet !)
* drop jansi (as DefaultClient should not depend on it)
* introduce two new jline3 terminal backends: jni and ffm (used on Java 22+)
* tested/verified (thanks @wendigo )