### PR TITLE
Make mvnd-1.x buildable with Java 21

### DIFF
--- a/integration-tests/src/test/projects/type-description/pom.xml
+++ b/integration-tests/src/test/projects/type-description/pom.xml
@@ -42,7 +42,7 @@
         <tar.long.file.mode>gnu</tar.long.file.mode>
         
         <!-- Quarkus Version -->
-        <quarkus.version>2.14.1.Final</quarkus.version>
+        <quarkus.version>3.10.0</quarkus.version>
 
         <!-- Jandex -->
         <jandex.version>3.0.3</jandex.version>

--- a/integration-tests/src/test/projects/type-description/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/AbstractEntity.java
+++ b/integration-tests/src/test/projects/type-description/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/AbstractEntity.java
@@ -15,10 +15,10 @@
  */
 package org.mvndaemon.mvnd.test.type.description.server.domain;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import java.io.Serializable;
 
 /**

--- a/integration-tests/src/test/projects/type-description/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/Image.java
+++ b/integration-tests/src/test/projects/type-description/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/Image.java
@@ -15,11 +15,11 @@
  */
 package org.mvndaemon.mvnd.test.type.description.server.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Lob;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import javax.sql.rowset.serial.SerialBlob;
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
So far it was buildable ONLY with Java 17, but only due single IT: it used old Quarkus version that refused to work on Java 21. Ported updates from mvnd master and now mvnd-1.x branch can also be build without any problem with Java 21.