### PR TITLE
Remove outdated note about oh-my-zsh

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,15 +113,6 @@ $ echo 'source $MVND_HOME/bin/mvnd-bash-completion.bash' >> ~/.bashrc
 ----
 `bash` is the only shell supported at this time.
 
-=== Note for oh-my-zsh users ===
-
-Users that use `oh-my-zsh` often use completion for maven.  The default maven completion plugin defines `mvnd` as an alias to `mvn deploy`. So before being able to use `mvnd`, you need to unalias using the following command:
-[source,shell]
-----
-$ unalias mvnd
-----
-
-
 === Install manually
 
 * Download the latest ZIP suitable for your platform from https://downloads.apache.org/maven/mvnd/


### PR DESCRIPTION
As a first-time user of the Maven Daemon, I was reading the README to make sure I apply everything that is relevant in my context.

I was curious about the note to the `oh-my-zsh` users, about a previous incompatibility between `mvnd` and the alias of the `mvn deploy` used by the `omz` maven plugin.

On a second look, it seems that the incompatibility has been resolved because `oh-my-zsh` has renamed `mvnd` to `mvndp` to resolve this particular problem.

Please check the relevant commit: https://github.com/ohmyzsh/ohmyzsh/pull/11756
and the linked issue: https://github.com/ohmyzsh/ohmyzsh/issues/11713

The up-to-date `omz maven plugin` documentation reflects the change: https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/mvn

| Alias                | Command                                         |
|:---------------------|:------------------------------------------------|
| `mvndp`               | `mvn deploy`                         |

Since this incompatibility seems to be no longer possible, I would suggest to drop this section from the documentation.

P.S. My PR does not link to an issue since I just considered it a simple cleanup. Should I create one?