### PR TITLE
Document installation instructions for MacPorts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,10 +66,16 @@ sense. With SDKMAN!, the `~/.m2/mvnd.properties` file is typically not needed at
 $ brew install mvndaemon/homebrew-mvnd/mvnd
 ----
 
+=== Install using https://www.macports.org[MacPorts]
+
+[source,shell]
+----
+$ sudo port install mvnd
+----
+
 === Other installers
 
-We're looking for contribution to support https://www.macports.org[MacPorts],
-https://community.chocolatey.org/packages/mvndaemon/[Chocolatey], https://scoop.sh/[Scoop] or
+We're looking for contribution to support https://community.chocolatey.org/packages/mvndaemon/[Chocolatey], https://scoop.sh/[Scoop] or
 https://github.com/joschi/asdf-mvnd#install[asdf].  If you fancy helping us...
 
 ////


### PR DESCRIPTION
Document how to install the [mvnd port](https://ports.macports.org/port/mvnd/) from MacPorts. (I'm the maintainer of the port.)