### PR TITLE
Move exception to a newline after a message

### DIFF
--- a/logging/src/main/java/org/mvndaemon/mvnd/logging/slf4j/MvndSimpleLogger.java
+++ b/logging/src/main/java/org/mvndaemon/mvnd/logging/slf4j/MvndSimpleLogger.java
@@ -108,6 +108,7 @@ public class MvndSimpleLogger extends MvndBaseLogger {
             builder.failure(t.getMessage());
         }
         builder.newline();
+        sb.append(System.lineSeparator());
         sb.append(builder);
 
         printStackTrace(t, builder, "");


### PR DESCRIPTION
This PR adds a line separator, which moves the exception to a new line instead of having it be concatenated.

Before the change, an example error would've been logged like this:
`[main] INFO test - info with exceptionjava.lang.RuntimeException: test exception`

After the change, the exception is separated with a new line:
```
[main] INFO test - info with exception
java.lang.RuntimeException: test exception
```

There is no test for this class, and I didn't find any other unit tests (only the integration ones), so I didn't create one.
I can set it up if needed, although a testing framework would have to be introduced too, as it's missing now afaik.