### PR TITLE
[1.x] Separate message and exception by newline

### DIFF
--- a/logging/src/main/java/org/slf4j/impl/MvndSimpleLogger.java
+++ b/logging/src/main/java/org/slf4j/impl/MvndSimpleLogger.java
@@ -168,6 +168,7 @@ public class MvndSimpleLogger extends MvndBaseLogger {
             return;
         }
         MessageBuilder builder = MessageUtils.buffer(sb);
+        builder.newline();
         builder.failure(t.getClass().getName());
         if (t.getMessage() != null) {
             builder.a(": ");


### PR DESCRIPTION
This was a small discrepancy to the output of vanilla Maven and made the output hard to read, since the failure class name started right after the message without any whitespace in between.