### PR TITLE
Separate message and exception by newline

### DIFF
--- a/logging/src/main/java/org/mvndaemon/mvnd/logging/slf4j/MvndSimpleLogger.java
+++ b/logging/src/main/java/org/mvndaemon/mvnd/logging/slf4j/MvndSimpleLogger.java
@@ -102,6 +102,7 @@ public class MvndSimpleLogger extends MvndBaseLogger {
             return;
         }
         MessageBuilder builder = MessageUtils.builder();
+        builder.newline();
         builder.failure(t.getClass().getName());
         if (t.getMessage() != null) {
             builder.a(": ");


### PR DESCRIPTION
This was a small discrepancy to the output of vanilla Maven and made the output
hard to read, since the failure class name started right after the message without
any whitespace in between.
