### PR TITLE
chore: make install commands copy+pastable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ If SDKMAN! supports your operating system, it is as easy as
 
 [source,shell]
 ----
-$ sdk install mvnd
+sdk install mvnd
 ----
 
 If you used the manual install in the past, please make sure that the settings in `~/.m2/mvnd.properties` still make
@@ -63,7 +63,7 @@ sense. With SDKMAN!, the `~/.m2/mvnd.properties` file is typically not needed at
 
 [source,shell]
 ----
-$ brew install mvndaemon/homebrew-mvnd/mvnd
+brew install mvndaemon/homebrew-mvnd/mvnd
 ----
 
 Note: There are two formulae: the `mvnd` that install latest, and `mvnd@1` that installs 1.x line.
@@ -72,7 +72,7 @@ Note: There are two formulae: the `mvnd` that install latest, and `mvnd@1` that 
 
 [source,shell]
 ----
-$ sudo port install mvnd
+sudo port install mvnd
 ----
 
 === Other installers


### PR DESCRIPTION
Readme cleanup to allow the install commands to be copied and pasted without modification.

This fixes the error:
```
zsh: command not found: $
```