### PR TITLE
Bump native-maven-plugin from 0.10.2 to 0.10.3

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -165,7 +165,7 @@
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <configuration>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg>
               </buildArgs>
             </configuration>
@@ -193,7 +193,7 @@
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <configuration>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc</buildArg>
                 <buildArg>-H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
                 <buildArg>-H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
@@ -215,7 +215,7 @@
               <skip>false</skip>
               <mainClass>org.mvndaemon.mvnd.client.DefaultClient</mainClass>
               <imageName>mvnd</imageName>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>-march=compatibility</buildArg>
                 <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -31,8 +31,6 @@
   <name>Maven Daemon - Client</name>
 
   <properties>
-    <graalvm-native-static-opt />
-    <graalvm-native-glibc-opt />
     <patchelf.skip>true</patchelf.skip>
   </properties>
 
@@ -161,9 +159,19 @@
           <family>!mac</family>
         </os>
       </activation>
-      <properties>
-        <graalvm-native-static-opt>-H:+StaticExecutableWithDynamicLibC</graalvm-native-static-opt>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <configuration>
+              <buildArgs combine.self="append">
+                <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -177,11 +185,23 @@
         </file>
       </activation>
       <properties>
-        <graalvm-native-glibc-opt>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc
-                                  -H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12
-                                  -H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</graalvm-native-glibc-opt>
         <patchelf.skip>false</patchelf.skip>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <configuration>
+              <buildArgs combine.self="append">
+                <buildArg>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc</buildArg>
+                <buildArg>-H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
+                <buildArg>-H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -195,17 +215,17 @@
               <skip>false</skip>
               <mainClass>org.mvndaemon.mvnd.client.DefaultClient</mainClass>
               <imageName>mvnd</imageName>
-              <buildArgs>--no-fallback
-                         -march=compatibility
-                         -H:+UnlockExperimentalVMOptions
-                         ${graalvm-native-static-opt}
-                         ${graalvm-native-glibc-opt}
-                         -H:IncludeResources=org/mvndaemon/mvnd/.*
-                         -H:IncludeResources=mvnd-bash-completion.bash
-                         -H:-ParseRuntimeOptions
-                         -H:+AddAllCharsets
-                         -H:+ReportExceptionStackTraces
-                         -ea</buildArgs>
+              <buildArgs combine.self="append">
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>-march=compatibility</buildArg>
+                <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
+                <buildArg>-H:IncludeResources=org/mvndaemon/mvnd/.*</buildArg>
+                <buildArg>-H:IncludeResources=mvnd-bash-completion.bash</buildArg>
+                <buildArg>-H:-ParseRuntimeOptions</buildArg>
+                <buildArg>-H:+AddAllCharsets</buildArg>
+                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+                <buildArg>-ea</buildArg>
+              </buildArgs>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <commons-compress.version>1.27.1</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>24.0.2</graalvm.version>
-    <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
+    <graalvm.plugin.version>0.10.3</graalvm.plugin.version>
     <groovy.version>4.0.22</groovy.version>
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <graalvm.version>24.0.2</graalvm.version>
     <graalvm.plugin.version>0.10.3</graalvm.plugin.version>
     <groovy.version>4.0.23</groovy.version>
-
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.3</jline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <graalvm.version>24.0.2</graalvm.version>
     <graalvm.plugin.version>0.10.3</graalvm.plugin.version>
     <groovy.version>4.0.23</groovy.version>
+
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.26.3</jline.version>


### PR DESCRIPTION
The plugin introduced some "windows fix"[1] that causes current arg parsing to fail. Solution seems to be to split each arg in own line, but that introduced another set of challenges.

[1] https://github.com/graalvm/native-build-tools/pull/609

Supersedes https://github.com/apache/maven-mvnd/pull/1133