### PR TITLE
Bump native-maven-plugin from 0.10.2 to 0.10.3

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -213,6 +213,9 @@
           <exists>target/graalvm-libs-for-glibc-2.12</exists>
         </file>
       </activation>
+      <properties>
+        <patchelf.skip>false</patchelf.skip>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -32,8 +32,6 @@
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
-    <graalvm-native-static-opt />
-    <graalvm-native-glibc-opt />
     <patchelf.skip>true</patchelf.skip>
   </properties>
 
@@ -190,9 +188,19 @@
           <family>!mac</family>
         </os>
       </activation>
-      <properties>
-        <graalvm-native-static-opt>-H:+StaticExecutableWithDynamicLibC</graalvm-native-static-opt>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <configuration>
+              <buildArgs combine.self="append">
+                <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -205,12 +213,21 @@
           <exists>target/graalvm-libs-for-glibc-2.12</exists>
         </file>
       </activation>
-      <properties>
-        <graalvm-native-glibc-opt>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc
-                                  -H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12
-                                  -H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</graalvm-native-glibc-opt>
-        <patchelf.skip>false</patchelf.skip>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <configuration>
+              <buildArgs combine.self="append">
+                <buildArg>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc</buildArg>
+                <buildArg>-H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
+                <buildArg>-H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -227,17 +244,17 @@
               <skip>false</skip>
               <mainClass>org.mvndaemon.mvnd.client.DefaultClient</mainClass>
               <imageName>mvnd</imageName>
-              <buildArgs>--no-fallback
-                         -march=compatibility
-                         -H:+UnlockExperimentalVMOptions
-                         ${graalvm-native-static-opt}
-                         ${graalvm-native-glibc-opt}
-                         -H:IncludeResources=org/mvndaemon/mvnd/.*
-                         -H:IncludeResources=mvnd-bash-completion.bash
-                         -H:-ParseRuntimeOptions
-                         -H:+AddAllCharsets
-                         -H:+ReportExceptionStackTraces
-                         -ea</buildArgs>
+              <buildArgs combine.self="append">
+                <buildArg>--no-fallback</buildArg>
+                <buildArg>-march=compatibility</buildArg>
+                <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
+                <buildArg>-H:IncludeResources=org/mvndaemon/mvnd/.*</buildArg>
+                <buildArg>-H:IncludeResources=mvnd-bash-completion.bash</buildArg>
+                <buildArg>-H:-ParseRuntimeOptions</buildArg>
+                <buildArg>-H:+AddAllCharsets</buildArg>
+                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
+                <buildArg>-ea</buildArg>
+              </buildArgs>
             </configuration>
             <executions>
               <execution>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -194,7 +194,7 @@
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <configuration>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg>
               </buildArgs>
             </configuration>
@@ -222,7 +222,7 @@
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
             <configuration>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>-H:CCompilerPath=${basedir}/src/main/resources/glibc/gcc</buildArg>
                 <buildArg>-H:CCompilerOption=-B${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
                 <buildArg>-H:CLibraryPath=${project.build.directory}/graalvm-libs-for-glibc-2.12</buildArg>
@@ -247,7 +247,7 @@
               <skip>false</skip>
               <mainClass>org.mvndaemon.mvnd.client.DefaultClient</mainClass>
               <imageName>mvnd</imageName>
-              <buildArgs combine.self="append">
+              <buildArgs combine.children="append">
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>-march=compatibility</buildArg>
                 <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -106,7 +106,7 @@
             <phase>none</phase>
           </execution>
           <execution>
-            <id>mvn-39</id>
+            <id>java-test</id>
             <goals>
               <goal>test</goal>
             </goals>
@@ -192,7 +192,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <executions>
               <execution>
-                <id>native-39</id>
+                <id>native-test</id>
                 <goals>
                   <goal>integration-test</goal>
                   <goal>verify</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <commons-compress.version>1.27.1</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>24.0.2</graalvm.version>
-    <graalvm.plugin.version>0.10.2</graalvm.plugin.version>
+    <graalvm.plugin.version>0.10.3</graalvm.plugin.version>
     <groovy.version>4.0.23</groovy.version>
     <jakarta.inject.version>1.0</jakarta.inject.version>
     <jline.version>3.26.3</jline.version>


### PR DESCRIPTION
The plugin introduced some "windows fix"[1] that causes current arg parsing to fail. Solution seems to be to split each arg in own line, but that introduced another set of challenges.

[1] https://github.com/graalvm/native-build-tools/pull/609

Supersedes https://github.com/apache/maven-mvnd/pull/1135