### PR TITLE
mvnd IT: increase connectTimeout for ITs

### DIFF
--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
@@ -81,7 +81,7 @@ public class DaemonMavenParser extends BaseMavenParser<MavenOptions, MavenInvoke
     @Override
     protected Map<String, String> populateUserProperties(LocalContext context) throws ParserException, IOException {
         HashMap<String, String> props = new HashMap<>(super.populateUserProperties(context));
-        props.put("maven.resolver.transport", "apache");
+        props.put("aether.transport.jdk.httpVersion", "HTTP_1_1");
         return props;
     }
 

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
@@ -81,7 +81,8 @@ public class DaemonMavenParser extends BaseMavenParser<MavenOptions, MavenInvoke
     @Override
     protected Map<String, String> populateUserProperties(LocalContext context) throws ParserException, IOException {
         HashMap<String, String> props = new HashMap<>(super.populateUserProperties(context));
-        props.put("maven.resolver.transport", "apache");
+        props.put("aether.transport.http.connectTimeout", "1800000");
+        props.put("aether.transport.http.requestTimeout", "1800000");
         return props;
     }
 

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.cli;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,13 @@ public class DaemonMavenParser extends BaseMavenParser<MavenOptions, MavenInvoke
                 .get();
         systemProperties.putAll(env);
         return systemProperties;
+    }
+
+    @Override
+    protected Map<String, String> populateUserProperties(LocalContext context) throws ParserException, IOException {
+        HashMap<String, String> props = new HashMap<>(super.populateUserProperties(context));
+        props.put("maven.resolver.transport", "apache");
+        return props;
     }
 
     @Override

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
@@ -18,7 +18,6 @@
  */
 package org.apache.maven.cli;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,14 +75,6 @@ public class DaemonMavenParser extends BaseMavenParser<MavenOptions, MavenInvoke
                 .get();
         systemProperties.putAll(env);
         return systemProperties;
-    }
-
-    @Override
-    protected Map<String, String> populateUserProperties(LocalContext context) throws ParserException, IOException {
-        HashMap<String, String> props = new HashMap<>(super.populateUserProperties(context));
-        props.put("aether.transport.http.connectTimeout", "1800000");
-        props.put("aether.transport.http.requestTimeout", "1800000");
-        return props;
     }
 
     @Override

--- a/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
+++ b/daemon/src/main/java/org/apache/maven/cli/DaemonMavenParser.java
@@ -81,7 +81,7 @@ public class DaemonMavenParser extends BaseMavenParser<MavenOptions, MavenInvoke
     @Override
     protected Map<String, String> populateUserProperties(LocalContext context) throws ParserException, IOException {
         HashMap<String, String> props = new HashMap<>(super.populateUserProperties(context));
-        props.put("aether.transport.jdk.httpVersion", "HTTP_1_1");
+        props.put("maven.resolver.transport", "apache");
         return props;
     }
 

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/JvmTestClient.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/JvmTestClient.java
@@ -30,6 +30,8 @@ import org.mvndaemon.mvnd.client.ExecutionResult;
 import org.mvndaemon.mvnd.common.Environment;
 import org.mvndaemon.mvnd.common.logging.ClientOutput;
 
+import static org.mvndaemon.mvnd.junit.TestUtils.augmentArgs;
+
 public class JvmTestClient extends DefaultClient {
 
     private final DaemonParameters parameters;
@@ -47,7 +49,7 @@ public class JvmTestClient extends DefaultClient {
         if (parameters instanceof TestParameters && ((TestParameters) parameters).isNoTransferProgress()) {
             argv.add("-ntp");
         }
-        final ExecutionResult delegate = super.execute(output, argv);
+        final ExecutionResult delegate = super.execute(output, augmentArgs(argv));
         if (output instanceof TestClientOutput) {
             return new JvmTestResult(delegate, ((TestClientOutput) output).messagesToString());
         }

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
@@ -35,6 +35,8 @@ import org.mvndaemon.mvnd.common.Message;
 import org.mvndaemon.mvnd.common.OsUtils.CommandProcess;
 import org.mvndaemon.mvnd.common.logging.ClientOutput;
 
+import static org.mvndaemon.mvnd.junit.TestUtils.augmentArgs;
+
 /**
  * A wrapper around the native executable.
  */
@@ -66,7 +68,8 @@ public class NativeTestClient implements Client {
     public ExecutionResult execute(ClientOutput output, List<String> args) throws InterruptedException {
         final List<String> cmd = new ArrayList<>(args.size() + 6);
         cmd.add(mvndNativeExecutablePath.toString());
-        cmd.addAll(args);
+        cmd.addAll(augmentArgs(args));
+
         add(Environment.MVND_DAEMON_STORAGE, cmd, parameters::daemonStorage);
         add(Environment.MAVEN_REPO_LOCAL, cmd, parameters::mavenRepoLocal);
         add(Environment.MAVEN_SETTINGS, cmd, parameters::settings);

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/TestUtils.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/TestUtils.java
@@ -21,10 +21,25 @@ package org.mvndaemon.mvnd.junit;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class TestUtils {
+    /**
+     * IT circumvention for JDK transport low timeouts and GH macOS runners networking issues.
+     * If arguments does not contain settings for timeouts (ie as part of test), they will be
+     * added to increase timeouts for IT runs.
+     */
+    public static List<String> augmentArgs(List<String> args) {
+        ArrayList<String> result = new ArrayList<>(args);
+        if (result.stream().noneMatch(s -> s.contains("aether.transport.http.connectTimeout"))) {
+            result.add("-Daether.transport.http.connectTimeout=1800000");
+        }
+        // note: def value for requestTimeout=1800000; not setting it as it is fine
+        return result;
+    }
 
     public static void replace(Path path, String find, String replacement) {
         try {


### PR DESCRIPTION
Experiment PR to figure out why MacOS GH runners keep failing with transport related (SSL handshake abort, HTTP timeouts) errors. As we know linux and windows boxes are in Azure, while macos boxes are somewhere else, and we get regularly real strange errors like "SSL handshake errors", "HTTP timeout error (against Central?)", so suspicion is on JDK transport (in HTTP/2 mode).

Experiments:
* force apache transport (HTTP/1.1) - :heavy_check_mark: 
* force JDK transport into HTTP/1.1 - :red_square: 
* use big timeout for connectTimeout - :heavy_check_mark: 

Conclusion: for ITs we will for now increase the default (10sec) `connectTimeout` Resolver configuration, as it seems too low.