### PR TITLE
Update m2.conf to match Maven 4.x

### DIFF
--- a/dist/src/main/distro/mvn/bin/m2.conf
+++ b/dist/src/main/distro/mvn/bin/m2.conf
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-main is org.apache.maven.cli.MavenCli from plexus.core
+main is ${maven.mainClass} from plexus.core
 
 set maven.conf default ${maven.home}/conf
 


### PR DESCRIPTION
So calling the `mvn` executable from a daemon distribution behaves more like vanilla Maven 4.x