### PR TITLE
Bug: extension handling

### DIFF
--- a/client/src/main/java/org/mvndaemon/mvnd/client/DaemonParameters.java
+++ b/client/src/main/java/org/mvndaemon/mvnd/client/DaemonParameters.java
@@ -450,12 +450,6 @@ public class DaemonParameters {
         if (env == Environment.MVND_EXT_CLASSPATH) {
             List<String> cp = parseExtClasspath(userHome());
             return String.join(",", cp);
-        } else if (env == Environment.MVND_CORE_EXTENSIONS_FILE_PATH) {
-            try {
-                return resolveCoreExtensionFilePath(multiModuleProjectDirectory());
-            } catch (IOException e) {
-                throw new RuntimeException("Unable to resolve core extension configuration file path", e);
-            }
         } else if (env == Environment.MVND_CORE_EXTENSIONS_EXCLUDE) {
             String exclusionsString = systemProperty(Environment.MVND_CORE_EXTENSIONS_EXCLUDE)
                     .orDefault()

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -212,11 +212,6 @@ public enum Environment {
      */
     MVND_EXT_CLASSPATH("mvnd.extClasspath", null, null, OptionType.STRING, Flags.DISCRIMINATING | Flags.INTERNAL),
     /**
-     * Internal option to specify the maven extension configuration file path to register.
-     */
-    MVND_CORE_EXTENSIONS_FILE_PATH(
-            "mvnd.coreExtensionFilePath", null, null, OptionType.STRING, Flags.DISCRIMINATING | Flags.INTERNAL),
-    /**
      * Internal option to specify comma separated list of maven extension G:As to exclude (to not load them from
      * .mvn/extensions.xml). This option makes possible for example that a project that with vanilla Maven would
      * use takari-smart-builder extension, remain buildable with mvnd (where use of this extension would cause issues).


### PR DESCRIPTION
mvnd still had mvn3 like code, just drop it and let base parser do the work. All the mvnd needs is filtering.

mvnd re extensions was still on mvn3 level, as it supported only one extnsions source. But in fact, the problem was that it override methods that were not needed to be overrridden.

Fixes #1280