### PR TITLE
[experiment] Mimir

### DIFF
--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<extensions>
+  <extension>
+    <groupId>eu.maveniverse.maven.mimir</groupId>
+    <artifactId>extension</artifactId>
+    <version>0.4.0</version>
+  </extension>
+</extensions>

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -119,13 +119,13 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare Mimir
+      - name: 'Prepare Mimir'
         shell: bash
         run: |
           mkdir -p ~/.m2
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
-      - name: Handle Mimir caches
+      - name: 'Handle Mimir caches'
         uses: actions/cache@v4
         with:
           path: ~/.mimir/local

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
+          key: mimir-${{ runner.os }}-default-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            mimir-${{ runner.os }}-initial-
+            mimir-${{ runner.os }}-default-
             mimir-${{ runner.os }}-
 
       - name: 'Run default (non-native) build'
@@ -125,9 +125,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
+          key: mimir-${{ runner.os }}-native-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            mimir-${{ runner.os }}-initial-
+            mimir-${{ runner.os }}-native-
             mimir-${{ runner.os }}-
 
       - name: 'Maven clean'

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -46,13 +46,13 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
-      - name: Prepare Mimir
+      - name: 'Prepare Mimir'
         shell: bash
         run: |
           mkdir -p ~/.m2
-          cp .github/ci-extensions.xml .mvn/extensions.xml
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
-      - name: Handle Mimir caches
+      - name: 'Handle Mimir caches'
         uses: actions/cache@v4
         with:
           path: ~/.mimir/local
@@ -60,6 +60,10 @@ jobs:
           restore-keys: |
             mimir-${{ runner.os }}-default-
             mimir-${{ runner.os }}-
+
+      - name: 'Set up Maven'
+        shell: bash
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
 
       - name: 'Run default (non-native) build'
         run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
@@ -119,7 +123,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
-          cp .github/ci-extensions.xml .mvn/extensions.xml
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
 
       - name: Handle Mimir caches
         uses: actions/cache@v4
@@ -129,6 +133,10 @@ jobs:
           restore-keys: |
             mimir-${{ runner.os }}-native-
             mimir-${{ runner.os }}-
+
+      - name: 'Set up Maven'
+        shell: bash
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
 
       - name: 'Maven clean'
         run: ./mvnw clean -Dmrm=false -V -B -ntp -e

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -46,6 +46,21 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
+      - name: Prepare Mimir
+        shell: bash
+        run: |
+          mkdir -p ~/.m2
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
+
+      - name: Handle Mimir caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.mimir/local
+          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir-${{ runner.os }}-initial-
+            mimir-${{ runner.os }}-
+
       - name: 'Run default (non-native) build'
         run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
@@ -99,6 +114,21 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Mimir
+        shell: bash
+        run: |
+          mkdir -p ~/.m2
+          cp .github/ci-extensions.xml ~/.m2/extensions.xml
+
+      - name: Handle Mimir caches
+        uses: actions/cache@v4
+        with:
+          path: ~/.mimir/local
+          key: mimir-${{ runner.os }}-initial-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir-${{ runner.os }}-initial-
+            mimir-${{ runner.os }}-
 
       - name: 'Maven clean'
         run: ./mvnw clean -Dmrm=false -V -B -ntp -e

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
-          cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-extensions.xml .mvn/extensions.xml
 
       - name: Handle Mimir caches
         uses: actions/cache@v4
@@ -119,7 +119,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.m2
-          cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-extensions.xml .mvn/extensions.xml
 
       - name: Handle Mimir caches
         uses: actions/cache@v4


### PR DESCRIPTION
Use Maveniverse Mimir to cache central artifacts. This makes caching way simpler as well. Update Maven used to build to Maven 4.0.0-rc-3 as well.