### PR TITLE
Adding mvnd for linux on docker on a mac.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,12 @@ jobs:
       matrix:
         # binaries wanted: linux amd64, mac intel, mac M1, windows x86
         os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
+        arch: [ x64, arm64 ]
+        exclude:
+          - os: macos-13
+            arch: arm64
+          - os: windows-latest
+            arch: arm64
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
I am trying to use mvnd in a devcontainer on a mac. There is no binary available to install. It is also missing from SDKMAN!