### PR TITLE
Build Site and fix 1288

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -20,9 +20,6 @@ name: Early Access
 # trigger on push to branches and PR
 on:
   push:
-    branches:
-      - master
-      - mvnd-1.x
   pull_request:
 
 env:

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -47,7 +47,7 @@ jobs:
           distribution: 'temurin'
 
       - name: 'Run default (non-native) build'
-        run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
+        run: ./mvnw verify site -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
       - name: 'Upload daemon test logs'
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,8 @@
     <version.plexus-xml>4.0.4</version.plexus-xml>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
 
+    <version.maven-fluido-skin>2.0.1</version.maven-fluido-skin>
+
     <!-- plugin versions a..z -->
     <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
     <groovy-maven-plugin.version>4.1.1</groovy-maven-plugin.version>


### PR DESCRIPTION
Besides a fix for #1288 the change also contains 

* a respective CI build (`mvn ... site`) to detect such problems early in the future
* a simplification for GH CI triggers (build on each push, not only master and PRs)

The latter leads to CI builds for each development change (which is a major purpose of an automatic build and helps in particular for forks/new contributors who cannot issue a automatic build by creating a PR). Having said that, the respective commit could be dropped if there is a good reason not to follow this practice.