### PR TITLE
Drop buildnumber plugin, Nisse is in place

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -78,21 +78,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>buildnumber-maven-plugin</artifactId>
-        <configuration>
-          <locale>en_US</locale>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>create</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>

--- a/client/src/main/resources/org/mvndaemon/mvnd/client/build.properties
+++ b/client/src/main/resources/org/mvndaemon/mvnd/client/build.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-revision=${buildNumber}
+revision=${nisse.jgit.commit}
 version=${project.version}
 os.detected.name=${os.detected.name}
 os.detected.arch=${os.detected.arch}

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
     <version.maven-fluido-skin>2.1.0</version.maven-fluido-skin>
 
     <!-- plugin versions a..z -->
-    <buildnumber-maven-plugin.version>3.2.1</buildnumber-maven-plugin.version>
     <groovy-maven-plugin.version>4.1.1</groovy-maven-plugin.version>
     <junit-platform-launcher.version>1.3.2</junit-platform-launcher.version>
     <takari-provisio.version>1.1.1</takari-provisio.version>
@@ -464,11 +463,6 @@
               <type>pom</type>
             </dependency>
           </dependencies>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>${buildnumber-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.graalvm.buildtools</groupId>


### PR DESCRIPTION
Just use Nisse, as it is already in place, plus it does not require git checkout either.

Fixes #1306 