### PR TITLE
Mimir: make sure JGroups is not running

### DIFF
--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Mimir Daemon properties
+
+# Disable JGroups; we don't want/use LAN cache sharing
+mimir.jgroups.enabled=false

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -59,10 +59,6 @@ jobs:
             mimir-${{ runner.os }}-default-
             mimir-${{ runner.os }}-
 
-      - name: 'Set up Maven'
-        shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
-
       - name: 'Run default (non-native) build'
         run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
@@ -133,10 +129,6 @@ jobs:
             mimir-${{ runner.os }}-native-
             mimir-${{ runner.os }}-
 
-      - name: 'Set up Maven'
-        shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
-
       - name: 'Maven clean'
         run: ./mvnw clean -Dmrm=false -V -B -ntp -e
 
@@ -199,10 +191,6 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-
-      - name: 'Set up Maven'
-        shell: bash
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.2:wrapper "-Dmaven=4.0.0-rc-3"
 
       - name: 'Run site build'
         run: ./mvnw compile site -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -43,11 +43,12 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
-      - name: 'Prepare Mimir'
+      - name: Prepare Mimir
         shell: bash
         run: |
-          mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
       - name: 'Handle Mimir caches'
         uses: actions/cache@v4
@@ -116,11 +117,12 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Prepare Mimir'
+      - name: Prepare Mimir
         shell: bash
         run: |
-          mkdir -p ~/.m2
+          mkdir -p ~/.mimir
           cp .github/ci-extensions.xml ~/.m2/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
 
       - name: 'Handle Mimir caches'
         uses: actions/cache@v4

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4-SNAPSHOT/apache-maven-4.0.0-rc-4-SNAPSHOT-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-4-SNAPSHOT/apache-maven-4.0.0-rc-4-SNAPSHOT-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-3/apache-maven-4.0.0-rc-3-bin.zip


### PR DESCRIPTION
We don't need it. Config copied from Maven.

For this to work (user wide extension) I upped Maven version to 4.0.0-rc-3 as well, again, same as in Maven CI.