### PR TITLE
Improve configuration for dependabot in 1.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,13 @@ updates:
     target-branch: "mvnd-1.x"
     labels:
       - "backport"
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "mvnd-1.x"
+    labels:
+      - "backport"
+      - "dependencies"


### PR DESCRIPTION
- add 'dependencies' label
- check GitHub Action in 1.x