### PR TITLE
[MNG-8315] Fix MAVEN_PROJECTBASEDIR in mvn.cmd when .mvn is at drive root

### DIFF
--- a/dist/src/main/distro/bin/mvnd.cmd
+++ b/dist/src/main/distro/bin/mvnd.cmd
@@ -189,6 +189,9 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 :endReadAdditionalConfig
 
+@REM do not let MAVEN_PROJECTBASEDIR end with a single backslash which would escape the double quote. This happens when .mvn at drive root.
+if "_%MAVEN_PROJECTBASEDIR:~-1%"=="_\" set "MAVEN_PROJECTBASEDIR=%MAVEN_PROJECTBASEDIR%\"
+
 for %%i in ("%MVND_HOME%"\mvn\boot\plexus-classworlds-*) do set CLASSWORLDS_JAR="%%i"
 set CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
 


### PR DESCRIPTION
Port from Maven core:
- https://github.com/apache/maven/pull/1808

reference issue:
 - https://issues.apache.org/jira/browse/MNG-8315