### PR TITLE
Update README.adoc to warn about non-standard defaults on hombrew cask recipe

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ sense. With SDKMAN!, the `~/.m2/mvnd.properties` file is typically not needed at
 brew install mvndaemon/homebrew-mvnd/mvnd
 ----
 
-Note: There are two formulae: the `mvnd` that install latest, and `mvnd@1` that installs 1.x line.
+Note: There are two formulae. Contrary to the recommendation by the [homebrew cask standards](https://docs.brew.sh/Acceptable-Casks#beta-unstable-development-nightly-or-legacy), the `mvnd` installs the preview 2.x version , and `mvnd@1` installs the stable 1.x version.
 
 === Install using https://www.macports.org[MacPorts]
 


### PR DESCRIPTION
The homebrew cask recipe installs the maven demon version 2.x by default, which expects maven 4 to be installed, is unstable and breaks most ci/cd systems. This behaviour is non standard and goes against the homebrew cask recommendations (see https://docs.brew.sh/Acceptable-Casks#beta-unstable-development-nightly-or-legacy and https://docs.brew.sh/Versions#acceptable-versioned-formulae). As it is expected that users will install the mvnd recipe right after mvn, this will likely cause them to get unexpected errors.

This updates the readme to warn future users that they will likely need to use the `mvnd@1` alternative.