### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -20,6 +20,9 @@ name: Early Access
 # trigger on push to branches and PR
 on:
   push:
+    branches:
+      - master
+      - mvnd-1.x
   pull_request:
 
 env:


### PR DESCRIPTION
On master it doubles CI jobs for all in-repo
PRs (as it is push but also PR).