### PR TITLE
backport: Make DaemonRegistry concurrency-safe

### DIFF
--- a/common/src/test/java/org/mvndaemon/mvnd/common/RegistryMutator.java
+++ b/common/src/test/java/org/mvndaemon/mvnd/common/RegistryMutator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.mvndaemon.mvnd.common;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * A class for testing multi-process safety in {@link DaemonRegistryTest}
+ */
+public class RegistryMutator {
+    public static void main(String[] args) {
+        Random random = new Random();
+        if (args[0].equals("add")) {
+            try (DaemonRegistry reg = new DaemonRegistry(Path.of(args[1]))) {
+                byte[] token = new byte[16];
+                random.nextBytes(token);
+                reg.store(new DaemonInfo(
+                        UUID.randomUUID().toString(),
+                        "/java/home/",
+                        "/data/reg/",
+                        random.nextInt(),
+                        "inet:/127.0.0.1:7502",
+                        token,
+                        Locale.getDefault().toLanguageTag(),
+                        Collections.singletonList("-Xmx"),
+                        DaemonState.Idle,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis()));
+            }
+        } else {
+            try (DaemonRegistry reg = new DaemonRegistry(Path.of(args[1]))) {
+                reg.remove(args[2]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The previous implementation had two issues:

The memmory-mapped file was created in the constructor and ignored file expansions by other threads or processes. It would then overwrite the file with its own, smaller size buffer. Replaced the memory mapping with a regular InputStream/OutputStream approach. Memory mapping is not very useful in this scenario anyway, since the file is small and infrequently read and we always read/write the entire file.

The tryLock method was broken and only tried locking once. If the lock could not be acquired, it returned null and the subsequent code then ignored that fact and proceeded without locking. I've moved the retry loop and failure handling into the lock method, which gives it the intended behavior of waiting for a lock for 20s and then failing.

The test expectation for the "big registry" test has changed, since we no longer manually increase the file size to multiples of two, but instead simply write out exactly the bytes we need.

I droped the String size requirement, since DataInputStream handles arbitrarly long Strings. I also changed the exception handling to consistently do recovery on any kind of exception while reading/writing, since it is reasonable to assume that any such exception indicates a broken registry file. I've also adjusted the user-facing message to only tell them to delete the file if recovery fails.

---

Backport of bb1191e4c6c80ec4a9b44dcc7888a202b5a3aef8