### PR TITLE
run assembly only on root project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
+            <inherited>false</inherited>
             <executions>
               <execution>
                 <id>create-source-distribution</id>
@@ -650,7 +651,6 @@
                 <phase>package</phase>
                 <configuration>
                   <finalName>maven-mvnd-${project.version}</finalName>
-                  <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
                   <descriptors>
                     <descriptor>src/main/assembly/src.xml</descriptor>
                   </descriptors>


### PR DESCRIPTION
before the change:
```
$ find . -name '*-src.zip'
./build-plugin/target/maven-mvnd-1.0.4-src.zip
./agent/target/maven-mvnd-1.0.4-src.zip
./client/target/maven-mvnd-1.0.4-src.zip
./dist/target/maven-mvnd-1.0.4-src.zip
./target/maven-mvnd-1.0.4-src.zip
./common/target/maven-mvnd-1.0.4-src.zip
./integration-tests/target/maven-mvnd-1.0.4-src.zip
./daemon/target/maven-mvnd-1.0.4-src.zip
./logging/target/maven-mvnd-1.0.4-src.zip
./native/target/maven-mvnd-1.0.4-src.zip
./helper/target/maven-mvnd-1.0.4-src.zip
```

not really a big problem, but it will be more efficient and clear to keep the assembly at root project