### PR TITLE
Fix flaky awaitIdle in integration tests

### DIFF
--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/TestRegistry.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/TestRegistry.java
@@ -72,7 +72,7 @@ public class TestRegistry extends DaemonRegistry {
      * @throws AssertionError        if the timeout is exceeded
      */
     public void awaitIdle(String daemonId) {
-        final int timeoutMs = 5000;
+        final int timeoutMs = 30_000;
         final long deadline = System.currentTimeMillis() + timeoutMs;
         while (getAll().stream()
                         .filter(di -> di.getId().equals(daemonId))
@@ -84,6 +84,12 @@ public class TestRegistry extends DaemonRegistry {
             Assertions.assertThat(deadline)
                     .withFailMessage("Daemon %s should have become idle within %d", daemonId, timeoutMs)
                     .isGreaterThan(System.currentTimeMillis());
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add 100ms sleep between polling iterations in `TestRegistry.awaitIdle()` to avoid tight busy-loop spinning on file lock acquisition
- Increase timeout from 5s to 30s to accommodate slow CI environments

## Problem

`StopStatusTest.stopStatus` (and other tests using `awaitIdle`) intermittently fail on macOS ARM64 CI runners with:
```
java.lang.AssertionError: Daemon <id> should have become idle within 5000
```

Root cause: `awaitIdle()` was a tight busy-loop calling `getAll()` on every iteration. Each `getAll()` call acquires a file lock on the daemon registry, causing contention. The 5000ms timeout was too short for CI runners under load.

## Test plan

- [x] Builds successfully
- The fix reduces lock contention and provides a more generous timeout, making the test robust on slow CI environments without significantly increasing test duration (the sleep only applies while waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)