### PR TITLE
Add takari smart builder to exported artifacts

### DIFF
--- a/daemon/src/main/resources/META-INF/maven/extension.xml
+++ b/daemon/src/main/resources/META-INF/maven/extension.xml
@@ -26,5 +26,7 @@ under the License.
 
     <exportedArtifacts>
         <exportedArtifact>org.codehaus.plexus:plexus-interactivity-api</exportedArtifact>
+        <!-- Not really exported (as package); here to prevent adding Takari Smart Builder as transitive of some extension like Tycho is -->
+        <exportedArtifact>io.takari.maven:takari-smart-builder</exportedArtifact>
     </exportedArtifacts>
 </extension>


### PR DESCRIPTION
But it is NOT REALLY an exported (by package) at all, but it prevents loading it as transitive dependency of any other extensions, like Tycho is.