### PR TITLE
Adds mvnd@2 formula

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ sense. With SDKMAN!, the `~/.m2/mvnd.properties` file is typically not needed at
 brew install mvndaemon/homebrew-mvnd/mvnd
 ----
 
-Note: There are two formulae: `mvnd` installs the preview 2.x version (embedding Maven 4.0.x), and `mvnd@1` installs the stable 1.x version (embedding Maven 3.9.x).
+Note: There are two formulae: `mvnd` installs the stable 1.x version (embedding Maven 3.9.x), and `mvnd@2` installs the preview 2.x version (embedding Maven 4.0.x).
 
 === Install using https://www.macports.org[MacPorts]
 


### PR DESCRIPTION
The mvnd@2 formula was added to the homebrew for advanced users, following the guidelines of the homebrew project in https://docs.brew.sh/Acceptable-Casks#beta-unstable-development-nightly-or-legacy

The readme should be updated to reflect the latest changes