### PR TITLE
Fix(#1555): stale plugin descriptor for rebuilt reactor plugins

### DIFF
--- a/daemon/src/main/java/org/mvndaemon/mvnd/cache/invalidating/InvalidatingRealmCacheEventSpy.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/cache/invalidating/InvalidatingRealmCacheEventSpy.java
@@ -37,6 +37,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.sisu.Typed;
+import org.mvndaemon.mvnd.cache.CacheRecord;
 import org.mvndaemon.mvnd.common.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,8 @@ public class InvalidatingRealmCacheEventSpy extends AbstractEventSpy {
     private final InvalidatingPluginRealmCache pluginCache;
     private final InvalidatingExtensionRealmCache extensionCache;
     private final InvalidatingProjectArtifactsCache projectArtifactsCache;
+    private final InvalidatingPluginDescriptorCache pluginDescriptorCache;
+    private final InvalidatingPluginArtifactsCache pluginArtifactsCache;
     private Path multiModuleProjectDirectory;
     private String pattern;
     private PathMatcher matcher;
@@ -59,10 +62,14 @@ public class InvalidatingRealmCacheEventSpy extends AbstractEventSpy {
     public InvalidatingRealmCacheEventSpy(
             InvalidatingPluginRealmCache cache,
             InvalidatingExtensionRealmCache extensionCache,
-            InvalidatingProjectArtifactsCache projectArtifactsCache) {
+            InvalidatingProjectArtifactsCache projectArtifactsCache,
+            InvalidatingPluginDescriptorCache pluginDescriptorCache,
+            InvalidatingPluginArtifactsCache pluginArtifactsCache) {
         this.pluginCache = cache;
         this.extensionCache = extensionCache;
         this.projectArtifactsCache = projectArtifactsCache;
+        this.pluginDescriptorCache = pluginDescriptorCache;
+        this.pluginArtifactsCache = pluginArtifactsCache;
     }
 
     @Override
@@ -110,6 +117,8 @@ public class InvalidatingRealmCacheEventSpy extends AbstractEventSpy {
                 /* Evict the entries referring to jars under multiModuleProjectDirectory */
                 pluginCache.cache.removeIf(this::shouldEvict);
                 extensionCache.cache.removeIf(this::shouldEvict);
+                pluginDescriptorCache.cache.removeIf((k, r) -> shouldEvict(r));
+                pluginArtifactsCache.cache.removeIf((k, r) -> shouldEvict(r));
                 MavenExecutionResult mer = (MavenExecutionResult) event;
                 List<MavenProject> projects = mer.getTopologicallySortedProjects();
                 projectArtifactsCache.cache.removeIf(
@@ -125,6 +134,30 @@ public class InvalidatingRealmCacheEventSpy extends AbstractEventSpy {
             InvalidatingProjectArtifactsCache.CacheKey k,
             InvalidatingProjectArtifactsCache.Record v) {
         return projects.stream().anyMatch(p -> k.matches(p.getGroupId(), p.getArtifactId(), p.getVersion()));
+    }
+
+    /**
+     * Evicts cache records (plugin descriptors, plugin artifacts) whose dependency paths refer to an
+     * artifact in the build tree or match the configured eviction pattern.
+     */
+    private boolean shouldEvict(CacheRecord record) {
+        try {
+            return record.getDependencyPaths().anyMatch(path -> {
+                if (path.startsWith(multiModuleProjectDirectory)) {
+                    LOG.debug("Removing cache entry because it refers to an artifact in the build tree {}", path);
+                    return true;
+                } else if (matcher != null && matcher.matches(path)) {
+                    LOG.debug(
+                            "Removing cache entry because its components {} matches the eviction pattern '{}'",
+                            path,
+                            pattern);
+                    return true;
+                }
+                return false;
+            });
+        } catch (Exception e) {
+            return true;
+        }
     }
 
     private boolean shouldEvict(InvalidatingPluginRealmCache.Key k, InvalidatingPluginRealmCache.Record v) {

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ReactorPluginDescriptorReloadTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/ReactorPluginDescriptorReloadTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.mvndaemon.mvnd.it;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mvndaemon.mvnd.assertj.TestClientOutput;
+import org.mvndaemon.mvnd.client.Client;
+import org.mvndaemon.mvnd.client.DaemonParameters;
+import org.mvndaemon.mvnd.junit.MvndNativeTest;
+import org.mvndaemon.mvnd.junit.TestUtils;
+
+/**
+ * Reproduces the case where a reactor plugin is rebuilt between two daemon invocations without being installed
+ * (so it is resolved as a {@code target/classes} directory). The plugin descriptor (e.g. parameter default values,
+ * the {@code threadSafe} flag, ...) is cached independently from the plugin realm and must be evicted as well,
+ * otherwise the daemon keeps serving the stale descriptor. See
+ * <a href="https://github.com/apache/maven-mvnd/issues/877">#877</a>.
+ */
+@MvndNativeTest(projectDir = "src/test/projects/module-and-plugin")
+class ReactorPluginDescriptorReloadTest {
+
+    @Inject
+    Client client;
+
+    @Inject
+    DaemonParameters parameters;
+
+    @Test
+    void reloadDescriptorOnReactorPluginChange() throws IOException, InterruptedException {
+        /* Note: we run "package" (not "install"), so the plugin is consumed from the reactor as a
+         * target/classes directory rather than from a freshly installed jar in the local repository. */
+        final Path helloPropertyPath =
+                parameters.multiModuleProjectDirectory().resolve("hello/target/hello.property.txt");
+
+        /* Build #1: the "property" parameter has its default value "Hello" */
+        {
+            final TestClientOutput output = new TestClientOutput();
+            client.execute(output, "clean", "package", "-e").assertSuccess();
+            Assertions.assertThat(helloPropertyPath)
+                    .usingCharset(StandardCharsets.UTF_8)
+                    .hasContent("Hello");
+        }
+
+        /* Build #2: change the parameter default value (a plugin descriptor change that does not alter the
+         * mojo's byte code path) and verify the daemon picks it up instead of reusing the stale descriptor. */
+        {
+            final Path mojoPath = parameters
+                    .multiModuleProjectDirectory()
+                    .resolve("plugin/src/main/java/org/mvndaemon/mvnd/test/module/plugin/mojo/HelloMojo.java");
+            TestUtils.replace(mojoPath, "defaultValue = \"Hello\"", "defaultValue = \"Goodbye\"");
+
+            Thread.sleep(200); // avoid intermittent timestamp resolution issues on some filesystems
+
+            final TestClientOutput output = new TestClientOutput();
+            client.execute(output, "clean", "package", "-e").assertSuccess();
+            Assertions.assertThat(helloPropertyPath)
+                    .usingCharset(StandardCharsets.UTF_8)
+                    .hasContent("Goodbye");
+        }
+    }
+}


### PR DESCRIPTION
## Problem
  
  When a project builds a Maven plugin in its own reactor (e.g. `mvnd verify`),
  subsequent daemon invocations keep serving a **stale plugin descriptor** even
  after the plugin's code changes. The reported symptom is the `threadSafe` flag
  not being re-read: toggle a Mojo's `@Mojo(threadSafe = ...)`, rebuild, and the
  daemon still uses the old value (#877).

  ## Root cause

  `InvalidatingRealmCacheEventSpy` already evicts reactor **plugin realms** and
  **extension realms** at the end of each build (any realm whose URLs point under
  `multiModuleProjectDirectory`). However, the `PluginDescriptor` — which carries
  the `threadSafe` flag, `@Parameter` default values, etc. — is stored in a
  separate singleton cache (`InvalidatingPluginDescriptorCache`) that was never
  evicted there.

  The timestamp-based invalidation cannot cover this case: with `verify`/`test`
  (no `install`), a reactor plugin is resolved to a `target/classes` **directory**.
  A directory's `lastModifiedTime` does not change when a `.class` file inside it
  is rewritten, so the cached descriptor's file state looks unchanged and the stale
  descriptor is reused. (The existing `ModuleAndPluginNativeIT` does not hit this
  because it uses `clean install`, which rewrites the jar in the local repo and
  bumps its mtime, invalidating everything.)

  ## Fix
  
  Extend `InvalidatingRealmCacheEventSpy` to also evict the
  `InvalidatingPluginDescriptorCache` and `InvalidatingPluginArtifactsCache`
  entries that refer to artifacts in the build tree (or match the configured
  `mvnd.pluginRealmEvictPattern`) at `MavenExecutionResult`. Eviction is driven by
  `CacheRecord.getDependencyPaths()`, consistent with the existing realm eviction.

  ## Test
  
  Adds `ReactorPluginDescriptorReloadTest`, which runs `clean package` (no install,
  so the plugin stays a `target/classes` directory), changes a `@Parameter`
  `defaultValue` between two daemon invocations, and asserts the new value takes
  effect. This fails before the fix and passes after.

  > Note: `integration-tests` test sources currently do not compile on master
  > (`JvmTestClient`/`MvndTestExtension` were not updated after the #970 client API
  > refactor), so this IT could not be run locally. The daemon change itself
  > compiles and passes spotless.

  Fixes #1555