### PR TITLE
Fix Maven fail-mode option parsing for -fae

### DIFF
--- a/client/src/test/java/org/mvndaemon/mvnd/client/EnvironmentTest.java
+++ b/client/src/test/java/org/mvndaemon/mvnd/client/EnvironmentTest.java
@@ -53,6 +53,26 @@ public class EnvironmentTest {
         assertEquals("", Environment.MAVEN_DEFINE.removeCommandLineOption(list("--define")));
     }
 
+    @Test
+    void mavenFileArguments() {
+        assertEquals("pom.xml", Environment.MAVEN_FILE.removeCommandLineOption(list("-f", "pom.xml")));
+        assertEquals("pom.xml", Environment.MAVEN_FILE.removeCommandLineOption(list("-fpom.xml")));
+        assertEquals("pom.xml", Environment.MAVEN_FILE.removeCommandLineOption(list("-f=pom.xml")));
+        assertEquals("pom.xml", Environment.MAVEN_FILE.removeCommandLineOption(list("--file", "pom.xml")));
+        assertEquals("pom.xml", Environment.MAVEN_FILE.removeCommandLineOption(list("--file=pom.xml")));
+    }
+
+    @Test
+    void mavenFailModeArgumentsAreNotMavenFileArguments() {
+        for (String failMode : Arrays.asList("-fae", "-ff", "-fn")) {
+            List<String> args = list(failMode, "verify");
+
+            Assertions.assertFalse(Environment.MAVEN_FILE.hasCommandLineOption(args));
+            Assertions.assertNull(Environment.MAVEN_FILE.removeCommandLineOption(args));
+            assertEquals(list(failMode, "verify"), args);
+        }
+    }
+
     private List<String> list(String... items) {
         return new ArrayList<>(Arrays.asList(items));
     }

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -314,6 +314,9 @@ public enum Environment {
     MVND_CANCEL_CONNECT_TIMEOUT("mvnd.cancelConnectTimeout", null, "3 seconds", OptionType.DURATION, Flags.NONE),
     ;
 
+    // Maven defines these as complete short options, not as "-f" with an attached value.
+    private static final Set<String> MAVEN_FILE_SHORT_OPTION_CONFLICTS = Set.of("-fae", "-ff", "-fn");
+
     static Properties properties;
 
     public static void setProperties(Properties properties) {
@@ -477,7 +480,8 @@ public enum Environment {
 
     public boolean hasCommandLineOption(Collection<String> args) {
         final String[] prefixes = getPrefixes();
-        return args.stream().anyMatch(arg -> Stream.of(prefixes).anyMatch(arg::startsWith));
+        return args.stream()
+                .anyMatch(arg -> Stream.of(prefixes).anyMatch(prefix -> matchesCommandLineOption(arg, prefix)));
     }
 
     public String getCommandLineOption(Collection<String> args) {
@@ -493,7 +497,7 @@ public enum Environment {
         String value = null;
         for (Iterator<String> it = args.iterator(); it.hasNext(); ) {
             String arg = it.next();
-            if (Stream.of(prefixes).anyMatch(arg::startsWith)) {
+            if (Stream.of(prefixes).anyMatch(prefix -> matchesCommandLineOption(arg, prefix))) {
                 if (remove) {
                     it.remove();
                 }
@@ -501,7 +505,7 @@ public enum Environment {
                     value = "";
                 } else {
                     String opt = Stream.of(prefixes)
-                            .filter(arg::startsWith)
+                            .filter(prefix -> matchesCommandLineOption(arg, prefix))
                             .max(Comparator.comparing(String::length))
                             .get();
                     value = arg.substring(opt.length());
@@ -521,6 +525,13 @@ public enum Environment {
             }
         }
         return value;
+    }
+
+    private boolean matchesCommandLineOption(String arg, String prefix) {
+        if (this == MAVEN_FILE && MAVEN_FILE_SHORT_OPTION_CONFLICTS.contains(arg)) {
+            return false;
+        }
+        return arg.startsWith(prefix);
     }
 
     private String[] getPrefixes() {


### PR DESCRIPTION
Fixes #1680

### Summary

This prevents mvnd's `MAVEN_FILE` option detection from treating Maven fail-mode short options (`-fae`, `-ff`, `-fn`) as `-f` with an attached value.

It keeps the existing supported `-f` and `--file` forms covered by tests, while allowing Maven's own parser to handle the fail-mode flags.

### Verification

- Reproduced the regression with a focused `EnvironmentTest` assertion before the fix.
- `./mvnw --batch-mode --no-transfer-progress -pl client -am -Dtest=EnvironmentTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw --batch-mode --no-transfer-progress -pl common,client -am test`
- `git diff --check`