### PR TITLE
Upgrade to Maven 4.0.0-SNAPSHOT (upcoming rc-6)

### DIFF
--- a/dist/src/main/provisio/maven-distro.xml
+++ b/dist/src/main/provisio/maven-distro.xml
@@ -28,9 +28,6 @@
         <artifact id="org.apache.maven.daemon:mvnd-logging:${project.version}">
             <exclusion id="*:*"/>
         </artifact>
-        <artifact id="org.slf4j:jul-to-slf4j">
-            <exclusion id="*:*"/>
-        </artifact>
         <artifact id="org.apache.maven.shared:maven-shared-utils">
             <exclusion id="*:*"/>
         </artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -81,14 +81,13 @@
     <graalvm.version>25.0.3</graalvm.version>
     <graalvm.plugin.version>1.1.3</graalvm.plugin.version>
     <groovy.version>5.0.6</groovy.version>
-    <jansi.version>2.4.1</jansi.version>
-    <jline.version>3.30.13</jline.version>
-    <maven.version>4.0.0-rc-5</maven.version>
+    <jline.version>4.3.1</jline.version>
+    <maven.version>4.0.0-SNAPSHOT</maven.version>
     <required-maven.version>3.9.10</required-maven.version>
 
     <!-- Keep in sync with Maven -->
-    <maven.resolver.version>2.0.18</maven.resolver.version>
-    <slf4j.version>2.0.17</slf4j.version>
+    <maven.resolver.version>2.0.21</maven.resolver.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <sisu.version>1.0.1</sisu.version>
     <maven.plugin-tools.version>3.15.2</maven.plugin-tools.version>
     <version.plexus-utils>4.0.2</version.plexus-utils>
@@ -336,7 +335,7 @@
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>
-        <artifactId>jline-terminal-jansi</artifactId>
+        <artifactId>jansi-core</artifactId>
         <version>${jline.version}</version>
       </dependency>
       <dependency>
@@ -400,6 +399,31 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>apache-snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>apache-snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
## Summary

- Upgrade `maven.version` from `4.0.0-rc-5` to `4.0.0-SNAPSHOT` (Maven 4.0.x branch, upcoming rc-6)
- Update synced dependencies to match Maven 4.0.x:
  - `maven.resolver.version`: 2.0.18 → 2.0.21
  - `slf4j.version`: 2.0.17 → 2.0.18
  - `jline.version`: 3.30.13 → 4.3.1 (jline 4.x, matching Maven 4.0.x)
  - `jline-terminal-jansi` → `jansi-core` (artifact renamed in jline 4.x)
- Remove explicit `jul-to-slf4j` from provisio assembly (already bundled in Maven 4.0.0-SNAPSHOT dist, causing a provisio conflict)
- Add Apache Snapshots repository for `4.0.0-SNAPSHOT` resolution

### Build status

- ✅ Full build (`mvn install -DskipTests`) passes
- ✅ All unit tests pass
- ⏳ Integration tests have pre-existing failures on master (multi-release JAR classpath issue, not related to this change)
- ⚠️ Draft PR — depends on `4.0.0-SNAPSHOT`, will need version update once rc-6 is released

## Test plan

- [x] `mvn install -DskipTests` — builds successfully
- [x] `mvn test -pl '!integration-tests'` — all unit tests pass
- [ ] Re-test once Maven 4.0.0-rc-6 is released and update version from SNAPSHOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)