### PR TITLE
Fix Early Access CI startup failure by pinning setup-graalvm to a SHA

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -110,8 +110,7 @@ jobs:
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up GraalVM'
-#        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1.5.6
-        uses: graalvm/setup-graalvm@v1.6.3
+        uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'


### PR DESCRIPTION
## Problem

The `Early Access` workflow has ended in `startup_failure` on **every push to master since 2026-06-16** (`0a172ea2`) — roughly seven weeks with no CI on master. A startup failure means GitHub rejected the workflow before scheduling anything, so there are no jobs, no logs, and no annotations to look at.

## Cause

`.github/workflows/early-access.yaml` referenced the GraalVM action by tag rather than by commit SHA:

```yaml
      - name: 'Set up GraalVM'
#        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1.5.6
        uses: graalvm/setup-graalvm@v1.6.3
```

The ASF org Actions policy only permits allowlisted third-party actions pinned to a full-length commit SHA, so the tag form is rejected at workflow-parse time. `c6df09e8` commented out the SHA pin in favour of a tag; subsequent Dependabot runs (`ae399981`) only bumped that tag, so the workflow stayed unrunnable.

## Evidence

- Last green run was `5f516c23`; the first failing run `0a172ea2` differed by exactly one line — the `setup-graalvm` ref.
- `release.yaml` on master already uses `graalvm/setup-graalvm@0def53c0…` (lines 74 and 153) and starts fine.
- The `mvnd-1.x` branch uses the same SHA-pinned ref; its runs reach the jobs (they end in `failure`, i.e. genuine test failures — a separate issue).
- The tag `v1.6.3` does resolve to `0def53c0…`, so this is not a missing-tag problem. Only the ref *form* differs.

## Fix

Restore the SHA pin, matching what `release.yaml` and `mvnd-1.x` already use:

```yaml
        uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
```

## Note

This restores workflow *startup* only. Master has had no CI coverage for ~7 weeks, so expect real build/test failures to surface once the jobs actually run — `mvnd-1.x` is currently red for that reason. Those should be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)