### PR TITLE
Revert org.graalvm.buildtools:native-maven-plugin from 1.1.6 to 1.1.3

### DIFF
--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -110,8 +110,7 @@ jobs:
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up GraalVM'
-#        uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1.5.6
-        uses: graalvm/setup-graalvm@v1.6.3
+        uses: graalvm/setup-graalvm@0def53c0fd8534bc13416c9469f5be45265824fd # v1.6.3
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'


### PR DESCRIPTION
Reverts the dependency bump from 1.1.3 to 1.1.6 that was introduced in commit bf4fabcf.

This version bump causes build failures on macOS-15 in the Early Access CI workflow (see https://github.com/apache/maven-mvnd/actions/runs/30857791437/job/91832747504).

Version 1.1.3 is known to work correctly with the current GraalVM setup.
