### PR TITLE
Bump native-maven-plugin to 1.1.7 to fix the native build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <assertj.version>3.27.7</assertj.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <graalvm.version>25.0.3</graalvm.version>
-    <graalvm.plugin.version>1.1.6</graalvm.plugin.version>
+    <graalvm.plugin.version>1.1.7</graalvm.plugin.version>
     <groovy.version>5.0.8</groovy.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.30.16</jline.version>


### PR DESCRIPTION
## Problem

Every `Build with GraalVM on *` job fails in the `Build native distribution` step:

```
[ERROR] Failed to execute goal org.graalvm.buildtools:native-maven-plugin:1.1.6:compile-no-fork
        (default) on project mvnd-client: A required class was missing:
        org/apache/maven/shared/utils/logging/MessageUtils

Caused by: java.lang.NoClassDefFoundError: org/apache/maven/shared/utils/logging/MessageUtils
    at AbstractNativeImageMojo.isColorEnabled (AbstractNativeImageMojo.java:314)
    at AbstractNativeImageMojo.addConsoleColorArgument (AbstractNativeImageMojo.java:305)
    at AbstractNativeImageMojo.getBuildArgs (AbstractNativeImageMojo.java:250)
    at NativeCompileNoForkMojo.generateBaseSBOMIfNeeded (NativeCompileNoForkMojo.java:166)
    at NativeCompileNoForkMojo.executeInternal (NativeCompileNoForkMojo.java:120)
Caused by: java.lang.ClassNotFoundException: org.apache.maven.shared.utils.logging.MessageUtils
```

## Cause

1.1.6 introduced `NativeCompileNoForkMojo.generateBaseSBOMIfNeeded`, and its call chain reaches `isColorEnabled()` — which in 1.1.6 is implemented as `return MessageUtils.isColorEnabled();`:

```java
// native-maven-plugin 1.1.6, AbstractNativeImageMojo.java:313
protected boolean isColorEnabled() {
    return MessageUtils.isColorEnabled();
}
```

`maven-shared-utils` is not among the plugin's declared dependencies (the plugin realm holds 26 jars, none of them `maven-shared-utils`) and it is not exported by the Maven core realm, so the class cannot be resolved. Verified against the jars: `AbstractNativeImageMojo.class` in 1.1.6 carries the `org/apache/maven/shared/utils/logging/MessageUtils` constant-pool reference; the same class in 1.1.3 does not. That is why this surfaced exactly on the 1.1.3 → 1.1.6 bump.

## Fix

1.1.7 removes the dependency, replacing it with the plugin's own `getMavenColorSetting()` / `parseMavenColorMode()` reading the `style.color` property. The `MessageUtils` reference is gone from the 1.1.7 jar entirely (0 occurrences vs 1 in 1.1.6).

## Related

The same bug is why apache/maven-mvnd#1702 (`1.1.3` → `1.1.6` on `mvnd-1.x`) is red — that branch should go to 1.1.7 rather than 1.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)