### PR TITLE
Pin org.graalvm.buildtools:native-maven-plugin to 1.1.3 for mvnd-1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>25.0.4</graalvm.version>
+    <!-- Stay at 1.1.3 - 1.1.6+ causes macOS-15 build failures -->
     <graalvm.plugin.version>1.1.3</graalvm.plugin.version>
     <groovy.version>5.0.8</groovy.version>
     <jakarta.inject.version>1.0.5</jakarta.inject.version>


### PR DESCRIPTION
Add comment to document staying at version 1.1.3 to prevent build failures
on macOS-15. Version 1.1.6+ causes the same issues that affected master
(see https://github.com/apache/maven-mvnd/actions/runs/30857791437/job/91832747504).

This serves as a safety measure against the pending dependabot PR that attempts to bump to 1.1.6.