### PR TITLE
Bump native-maven-plugin to 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <!-- cannot upgrade graalvm to 23.0.0 which requires JDK >= 20 -->
     <graalvm.version>25.0.4</graalvm.version>
-    <graalvm.plugin.version>1.1.3</graalvm.plugin.version>
+    <graalvm.plugin.version>1.1.7</graalvm.plugin.version>
     <groovy.version>5.0.8</groovy.version>
     <jakarta.inject.version>1.0.5</jakarta.inject.version>
     <jline.version>3.30.13</jline.version>


### PR DESCRIPTION
Supersedes #1702, which bumps `1.1.3` → `1.1.6` and turns every native build red.

## Why 1.1.6 fails

```
[ERROR] Failed to execute goal org.graalvm.buildtools:native-maven-plugin:1.1.6:compile-no-fork
        (default) on project mvnd-client: A required class was missing:
        org/apache/maven/shared/utils/logging/MessageUtils

Caused by: java.lang.NoClassDefFoundError: org/apache/maven/shared/utils/logging/MessageUtils
    at AbstractNativeImageMojo.isColorEnabled (AbstractNativeImageMojo.java:314)
    at AbstractNativeImageMojo.addConsoleColorArgument (AbstractNativeImageMojo.java:305)
    at AbstractNativeImageMojo.getBuildArgs (AbstractNativeImageMojo.java:250)
    at NativeCompileNoForkMojo.generateBaseSBOMIfNeeded (NativeCompileNoForkMojo.java:166)
    at NativeCompileNoForkMojo.executeInternal (NativeCompileNoForkMojo.java:120)
Caused by: java.lang.ClassNotFoundException: org.apache.maven.shared.utils.logging.MessageUtils
```

1.1.6 introduced `NativeCompileNoForkMojo.generateBaseSBOMIfNeeded`, and its call chain reaches `isColorEnabled()`, implemented in 1.1.6 as:

```java
// AbstractNativeImageMojo.java:313
protected boolean isColorEnabled() {
    return MessageUtils.isColorEnabled();
}
```

`maven-shared-utils` is not among the plugin's declared dependencies (26 jars in the plugin realm, none of them it) and is not exported by the Maven core realm, so the class cannot be resolved.

This is not macOS-specific — it hits every platform and every Maven version, because nothing puts `maven-shared-utils` on that realm.

## Why 1.1.7 is safe

1.1.7 removes the reference, replacing it with the plugin's own `getMavenColorSetting()` / `parseMavenColorMode()` reading the `style.color` property. Verified against the artifacts: `AbstractNativeImageMojo.class` in 1.1.6 carries the `org/apache/maven/shared/utils/logging/MessageUtils` constant-pool reference, the same class in 1.1.3 does not, and the 1.1.7 jar contains zero occurrences of it.

So the fix is to move forward to 1.1.7 rather than to stay pinned at 1.1.3.

The same bump for `master` is in #1706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)