### PR TITLE
Upgrade CI Mimir extension to 0.12.0

### DIFF
--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -18,7 +18,7 @@ under the License.
 <extensions>
   <extension>
     <groupId>eu.maveniverse.maven.mimir</groupId>
-    <artifactId>extension</artifactId>
-    <version>0.7.0</version>
+    <artifactId>extension3</artifactId>
+    <version>0.12.0</version>
   </extension>
 </extensions>

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -57,10 +57,10 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-default-${{ hashFiles('**/pom.xml') }}
+          key: mimir2-${{ runner.os }}-default-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            mimir-${{ runner.os }}-default-
-            mimir-${{ runner.os }}-
+            mimir2-${{ runner.os }}-default-
+            mimir2-${{ runner.os }}-
 
       - name: 'Run default (non-native) build'
         run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
@@ -127,10 +127,10 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.mimir/local
-          key: mimir-${{ runner.os }}-native-${{ hashFiles('**/pom.xml') }}
+          key: mimir2-${{ runner.os }}-native-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            mimir-${{ runner.os }}-native-
-            mimir-${{ runner.os }}-
+            mimir2-${{ runner.os }}-native-
+            mimir2-${{ runner.os }}-
 
       - name: 'Maven clean'
         run: ./mvnw clean -Dmrm=false -V -B -ntp -e


### PR DESCRIPTION
Every CI build currently prints, twice per job:

```
[INFO] Please upgrade to Mimir version 0.9.4 (you are using version 0.7.0)
[INFO] Resolving Mimir daemon version 0.7.0
```

It is only an INFO nag — nothing fails because of it — but 0.7.0 is well behind.

## Coordinate change

`eu.maveniverse.maven.mimir:extension` was discontinued after 0.7.9. From 0.8.0 onward `extension3` is the single artifact covering both Maven 3 and Maven 4, so the artifactId changes along with the version:

```xml
<extension>
  <groupId>eu.maveniverse.maven.mimir</groupId>
  <artifactId>extension3</artifactId>
  <version>0.12.0</version>
</extension>
```

0.12.0 is the current release. Upstream tests against 3.9.11 and 4.0.0-rc-5; the wrapper here uses 4.0.0-rc-5. Requirements are Java 17+, satisfied by the Java 25 CI toolchain.

Going to 0.12.0 rather than the suggested 0.9.4 — the nag text is stale, 0.12.0 is what is actually current.

## Cache keys

Mimir 0.11.0 changed the local cache format and states existing caches must be dropped and rebuilt. The GitHub cache keys therefore move from `mimir-*` to `mimir2-*`; keeping the old prefix would let `restore-keys` pull a 0.7.0-format cache into a 0.12.0 daemon. First run on each OS repopulates from scratch.

## Unchanged

`.github/ci-mimir-daemon.properties` needs no change — `mimir.jgroups.enabled` is still a valid property (`node/jgroups/.../JGroupsNodeConfig.java`), so LAN cache sharing stays off. Placement of `extensions.xml` in `~/.m2/` is also still correct for Maven 4-rc-5+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)