### PR TITLE
Enable Mimir build cache in CI

### DIFF
--- a/.github/ci-extensions.xml
+++ b/.github/ci-extensions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<extensions>
+  <extension>
+    <groupId>eu.maveniverse.maven.mimir</groupId>
+    <artifactId>extension3</artifactId>
+    <version>0.12.0</version>
+  </extension>
+</extensions>

--- a/.github/ci-mimir-daemon.properties
+++ b/.github/ci-mimir-daemon.properties
@@ -1,0 +1,21 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Mimir Daemon properties
+
+# Disable JGroups; we don't want/use LAN cache sharing
+mimir.jgroups.enabled=false

--- a/.github/workflows/early-access.yaml
+++ b/.github/workflows/early-access.yaml
@@ -46,6 +46,22 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
 
+      - name: 'Prepare Mimir'
+        shell: bash
+        run: |
+          mkdir -p ~/.mimir
+          cp .github/ci-extensions.xml .mvn/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
+
+      - name: 'Handle Mimir caches'
+        uses: actions/cache@v6
+        with:
+          path: ~/.mimir/local
+          key: mimir2-${{ runner.os }}-default-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir2-${{ runner.os }}-default-
+            mimir2-${{ runner.os }}-
+
       - name: 'Run default (non-native) build'
         run: ./mvnw verify -Dmrm=false -V -B -ntp -e -s .mvn/release-settings.xml
 
@@ -98,6 +114,22 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Prepare Mimir'
+        shell: bash
+        run: |
+          mkdir -p ~/.mimir
+          cp .github/ci-extensions.xml .mvn/extensions.xml
+          cp .github/ci-mimir-daemon.properties ~/.mimir/daemon.properties
+
+      - name: 'Handle Mimir caches'
+        uses: actions/cache@v6
+        with:
+          path: ~/.mimir/local
+          key: mimir2-${{ runner.os }}-native-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            mimir2-${{ runner.os }}-native-
+            mimir2-${{ runner.os }}-
 
       - name: 'Maven clean'
         run: ./mvnw clean -Dmrm=false -V -B -ntp -e


### PR DESCRIPTION
`mvnd-1.x` has no Mimir setup at all today — no `.github/ci-extensions.xml`, no daemon properties, no cache steps — so there is nothing to bump here. This ports what `master` has (see #1709) rather than upgrading a version.

Added:

- `.github/ci-extensions.xml` — `eu.maveniverse.maven.mimir:extension3:0.12.0`
- `.github/ci-mimir-daemon.properties` — JGroups off, no LAN cache sharing
- `Prepare Mimir` + `Handle Mimir caches` steps in both the default and the native job

## Two deliberate differences from master

**1. The extensions file goes to `.mvn/extensions.xml`, not `~/.m2/extensions.xml`.**

`mvnd-1.x` builds with the Maven 3.9.14 wrapper. Upstream is explicit that the user-wide location is Maven 4 only:

> With Maven 3 create project-wide, or with Maven 4-rc-5+ create user-wide `~/.m2/extensions.xml`

Copying to `~/.m2/` as master does would silently do nothing here — the extension would never load and the cache would never be populated. The existing `.mvn/extensions.xml` is an empty `<extensions/>` element, so overwriting it during the build loses nothing, and no plugin in this branch checks for a clean working tree (no `doCheck` on buildnumber-maven-plugin).

**2. The artifact is `extension3`.**

`eu.maveniverse.maven.mimir:extension` was discontinued after 0.7.9; since 0.8.0 `extension3` is the single artifact covering both Maven 3 and Maven 4. Requirements are Maven 3.9+ and Java 17+ — satisfied by 3.9.14 and the Java 22 CI toolchain.

## Cache keys

Uses the `mimir2-` prefix, same as master after #1709. Caches created on the default branch are visible to other branches, so a shared prefix is only safe because both branches would be on the same 0.12.0 cache format — Mimir 0.11.0 changed that format and requires older caches to be dropped.

## Note

This is new CI infrastructure for this branch, so the first run on each OS populates the cache from scratch and shows no speedup; the benefit appears on subsequent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)