### PR TITLE
test: prevent ambient environment from leaking into daemon builds on CI (2.x)

### DIFF
--- a/client/src/main/java-mvnd/org/mvndaemon/mvnd/client/DefaultClient.java
+++ b/client/src/main/java-mvnd/org/mvndaemon/mvnd/client/DefaultClient.java
@@ -242,6 +242,15 @@ public class DefaultClient implements Client {
                 true);
     }
 
+    /**
+     * The environment forwarded to the daemon in the {@link Message.BuildRequest}. Defaults to the
+     * client's own environment; overridable so tests can run hermetically (e.g. without inheriting
+     * an ambient {@code MAVEN_ARGS}).
+     */
+    protected Map<String, String> buildRequestEnvironment() {
+        return System.getenv();
+    }
+
     @Override
     public ExecutionResult execute(ClientOutput output, List<String> argv) {
         LOGGER.debug("Starting client");
@@ -374,7 +383,7 @@ public class DefaultClient implements Client {
                         args,
                         parameters.userDir().toString(),
                         parameters.multiModuleProjectDirectory().toString(),
-                        System.getenv()));
+                        buildRequestEnvironment()));
 
                 output.accept(Message.buildStatus(
                         "Connected to daemon " + daemon.getDaemon().getId() + ", scanning for projects..."));

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/JvmTestClient.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/JvmTestClient.java
@@ -21,6 +21,7 @@ package org.mvndaemon.mvnd.junit;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +41,18 @@ public class JvmTestClient extends DefaultClient {
     public JvmTestClient(DaemonParameters parameters) {
         super(parameters);
         this.parameters = parameters;
+    }
+
+    /**
+     * Strip any ambient {@code MAVEN_ARGS} (e.g. actions/setup-java sets it to {@code -ntp}) from the
+     * environment forwarded to the daemon, so it cannot override per-test flags such as
+     * ConcurrentDownloadsTest's transfer-progress expectation. Keeps the test daemon hermetic.
+     */
+    @Override
+    protected Map<String, String> buildRequestEnvironment() {
+        final Map<String, String> env = new HashMap<>(super.buildRequestEnvironment());
+        env.remove("MAVEN_ARGS");
+        return env;
     }
 
     @Override

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/MvndTestExtension.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/MvndTestExtension.java
@@ -21,6 +21,7 @@ package org.mvndaemon.mvnd.junit;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -235,7 +236,7 @@ public class MvndTestExtension implements BeforeAllCallback, BeforeEachCallback,
                     multiModuleProjectDirectory,
                     Paths.get(System.getProperty("java.home")).toAbsolutePath().normalize(),
                     localMavenRepository,
-                    null,
+                    createIsolatedSettings(testDir.resolve("settings.xml")),
                     TimeUtils.toDuration(Environment.MVND_IDLE_TIMEOUT.getDefault()),
                     keepAlive != null && !keepAlive.isEmpty()
                             ? TimeUtils.toDuration(keepAlive)
@@ -249,6 +250,24 @@ public class MvndTestExtension implements BeforeAllCallback, BeforeEachCallback,
             final TestRegistry registry = new TestRegistry(parameters.registry());
 
             return new MvndResource(parameters, registry, isNative, timeoutMs);
+        }
+
+        /**
+         * Writes a minimal, isolated {@code settings.xml} and returns its path so that the daemon
+         * is always launched with an explicit {@code -s} and never falls back to the ambient
+         * {@code ${user.home}/.m2/settings.xml}. Without this, when running with {@code -Dmrm=false}
+         * (as CI does), the daemon reads the runner's user settings. actions/setup-java writes one
+         * containing {@code <interactiveMode>false</interactiveMode>}, which made {@code versions:set}
+         * run non-interactively and broke InteractiveTest. An empty settings keeps the defaults
+         * (interactive, no ambient mirrors) so the tests behave the same everywhere.
+         */
+        static Path createIsolatedSettings(Path settingsPath) {
+            try {
+                Files.write(settingsPath, "<settings/>\n".getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new RuntimeException("Could not write " + settingsPath, e);
+            }
+            return settingsPath;
         }
 
         private static void prefillLocalRepo(final Path localMavenRepository) {

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
@@ -82,6 +82,9 @@ public class NativeTestClient implements Client {
                 .redirectErrorStream(true);
 
         final Map<String, String> env = builder.environment();
+        // Strip any ambient MAVEN_ARGS (e.g. actions/setup-java sets it to -ntp) so it cannot leak
+        // through the native binary into the daemon and override per-test flags. Keeps tests hermetic.
+        env.remove("MAVEN_ARGS");
         if (!Environment.MVND_HOME.hasCommandLineOption(args)) {
             env.put(Environment.MVND_HOME.getEnvironmentVariable(), Environment.MVND_HOME.asString());
         }


### PR DESCRIPTION
### Description
Backports the integration test hermeticity fixes from `mvnd-1.x` (commit b3a40f2f4afa295d042fc2fd7de144c0a4cd2c48 / PR #1666) to `master` (`2.x`).

- Extract `buildRequestEnvironment()` in `DefaultClient` for subclass override.
- Strip `MAVEN_ARGS` from `JvmTestClient` and `NativeTestClient` to block per-test flag overrides by ambient environment variables on CI.
- Write an isolated `settings.xml` in `MvndTestExtension` so daemon tests never fall back to the runner's user settings (`~/.m2/settings.xml`).