### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.mvn/release-settings.xml
+++ b/.mvn/release-settings.xml
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <profiles>
-        <profile>
-            <id>maven-staging</id>
-            <repositories>
-                <repository>
-                    <id>maven-staging-rc1</id>
-                    <url>https://repository.apache.org/content/repositories/maven-2247/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
-    <activeProfiles>
-        <activeProfile>maven-staging</activeProfile>
-    </activeProfiles>
 </settings>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-5/apache-maven-4.0.0-rc-5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-6/apache-maven-4.0.0-rc-6-bin.zip

--- a/dist/src/main/provisio/maven-distro.xml
+++ b/dist/src/main/provisio/maven-distro.xml
@@ -28,9 +28,6 @@
         <artifact id="org.apache.maven.daemon:mvnd-logging:${project.version}">
             <exclusion id="*:*"/>
         </artifact>
-        <artifact id="org.slf4j:jul-to-slf4j">
-            <exclusion id="*:*"/>
-        </artifact>
         <artifact id="org.apache.maven.shared:maven-shared-utils">
             <exclusion id="*:*"/>
         </artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <groovy.version>5.0.8</groovy.version>
     <jansi.version>2.4.1</jansi.version>
     <jline.version>3.30.16</jline.version>
-    <maven.version>4.0.0-rc-5</maven.version>
+    <maven.version>4.0.0-rc-6</maven.version>
     <required-maven.version>3.9.10</required-maven.version>
 
     <!-- Keep in sync with Maven -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
     <!-- Keep in sync with Maven -->
     <maven.resolver.version>2.0.20</maven.resolver.version>
-    <slf4j.version>2.0.17</slf4j.version>
+    <slf4j.version>2.0.18</slf4j.version>
     <sisu.version>1.1.0</sisu.version>
     <maven.plugin-tools.version>3.15.2</maven.plugin-tools.version>
     <version.plexus-utils>4.0.2</version.plexus-utils>

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,12 @@
     <graalvm.version>25.0.3</graalvm.version>
     <graalvm.plugin.version>1.1.7</graalvm.plugin.version>
     <groovy.version>5.0.8</groovy.version>
-    <jansi.version>2.4.1</jansi.version>
-    <jline.version>3.30.16</jline.version>
+    <jline.version>4.3.1</jline.version>
     <maven.version>4.0.0-rc-6</maven.version>
     <required-maven.version>3.9.10</required-maven.version>
 
     <!-- Keep in sync with Maven -->
-    <maven.resolver.version>2.0.20</maven.resolver.version>
+    <maven.resolver.version>2.0.21</maven.resolver.version>
     <slf4j.version>2.0.18</slf4j.version>
     <sisu.version>1.1.0</sisu.version>
     <maven.plugin-tools.version>3.15.2</maven.plugin-tools.version>
@@ -336,7 +335,7 @@
       </dependency>
       <dependency>
         <groupId>org.jline</groupId>
-        <artifactId>jline-terminal-jansi</artifactId>
+        <artifactId>jansi-core</artifactId>
         <version>${jline.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Moves `maven.version` to the current RC, and the wrapper `distributionUrl` with it so the two do not drift apart.

Note: this repo's workflows only trigger on pushes to `master`/`mvnd-1.x` and on `pull_request`, so it could not be pre-verified on a fork branch — CI runs here on the PR.
