### PR TITLE
fix: feed real stdin to native mvnd process in NativeTestClient

### DIFF
--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/assertj/TestClientOutput.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/assertj/TestClientOutput.java
@@ -71,6 +71,17 @@ public class TestClientOutput implements ClientOutput {
         return messages;
     }
 
+    /**
+     * Bytes to feed to the real OS-level stdin of a natively spawned {@code mvnd} process
+     * (see {@code NativeTestClient}), or {@code null} if the test doesn't need to simulate stdin.
+     * The {@link #accept(Message)}-based {@code RequestInput}/{@code RequestInputAvailable}
+     * interception only works for the in-process JVM test client, since for a native test the
+     * daemon talks to the spawned binary's own real stdin, which this JVM never sees as messages.
+     */
+    public byte[] nativeStdin() {
+        return null;
+    }
+
     public void assertContainsMatchingSubsequence(String... patterns) {
         Assertions.assertThat(messagesToString()).is(new MatchInOrderAmongOthers<>(patterns));
     }

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/InputStreamNativeIT.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/InputStreamNativeIT.java
@@ -21,6 +21,7 @@ package org.mvndaemon.mvnd.it;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 import org.mvndaemon.mvnd.assertj.TestClientOutput;
@@ -84,6 +85,11 @@ class InputStreamNativeIT {
                 if (!(message instanceof Message.TransferEvent)) {
                     super.accept(message);
                 }
+            }
+
+            @Override
+            public byte[] nativeStdin() {
+                return data.getBytes(StandardCharsets.UTF_8);
             }
         };
         client.execute(output, "install").assertSuccess();

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/junit/NativeTestClient.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.mvndaemon.mvnd.assertj.TestClientOutput;
 import org.mvndaemon.mvnd.client.Client;
 import org.mvndaemon.mvnd.client.DaemonParameters;
 import org.mvndaemon.mvnd.client.ExecutionResult;
@@ -100,10 +101,22 @@ public class NativeTestClient implements Client {
                 log.add(s);
             }
         };
-        try (CommandProcess process =
-                new CommandProcess(builder.start(), loggingConsumer.andThen(s -> output.accept(Message.log(s))))) {
-            final int exitCode = process.waitFor(timeoutMs);
-            return new Result(args, exitCode, log);
+        try {
+            final Process rawProcess = builder.start();
+            if (output instanceof TestClientOutput) {
+                final byte[] stdin = ((TestClientOutput) output).nativeStdin();
+                if (stdin != null) {
+                    // Feed the process's real stdin, like piping data into a real mvnd invocation.
+                    // The daemon talks to this spawned binary's own stdin, not to any in-JVM message queue.
+                    rawProcess.getOutputStream().write(stdin);
+                    rawProcess.getOutputStream().close();
+                }
+            }
+            try (CommandProcess process =
+                    new CommandProcess(rawProcess, loggingConsumer.andThen(s -> output.accept(Message.log(s))))) {
+                final int exitCode = process.waitFor(timeoutMs);
+                return new Result(args, exitCode, log);
+            }
         } catch (IOException e) {
             throw new RuntimeException("Could not execute: " + cmdString, e);
         }


### PR DESCRIPTION
## Summary
- `InputStreamNativeIT.installPluginAndCount` fails on CI (native GraalVM builds) because `NativeTestClient` spawns the real `mvnd` binary but never writes to or closes its stdin pipe.
- The test's `RequestInput`/`RequestInputAvailable` message interception in `TestClientOutput` only works for the in-process JVM test client; for a native test the daemon talks to the spawned binary's own real OS-level stdin, which the harness never fed, so the mojo always saw 0 bytes available instead of the expected 10.
- Adds `TestClientOutput.nativeStdin()` (defaults to `null`, so no behavior change for any other test) so a native IT can supply bytes that get written to the child process's real stdin and closed (EOF) before the daemon requests them, mirroring how a real `pipe | mvnd ...` invocation behaves.

Confirmed on `apache/maven-mvnd`'s own `master` CI (e.g. run 30862194274, headSha `67d0a23d`) that this failure is pre-existing and unrelated to any particular feature branch — it reproduces identically on unmodified `master`.

## Test plan
- [x] `./mvnw -pl dist -am install -DskipTests` then `./mvnw -pl integration-tests test -Dtest=InputStreamNativeIT` locally — compiles cleanly; fails only with "mvnd executable does not exist" since no GraalVM `native-image` toolchain is available in this environment (expected/inherent local limitation, not a code issue).
- [x] `./mvnw -pl integration-tests test -Dtest=InputStreamTest` (JVM-mode counterpart) — passes, confirming the new `nativeStdin()` default is a no-op for the existing path.
- [x] CI (GraalVM native builds on ubuntu/macos/windows) to confirm `InputStreamNativeIT.installPluginAndCount` now passes (`ubuntu-24.04-arm` build pending the merge of 5f53708).

🤖 Generated with [Claude Code](https://claude.com/claude-code)