### PR TITLE
Drop two pom properties the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,7 @@
     <slf4j.version>2.0.18</slf4j.version>
     <sisu.version>1.1.0</sisu.version>
     <maven.plugin-tools.version>3.15.2</maven.plugin-tools.version>
-    <version.plexus-utils>4.0.2</version.plexus-utils>
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
-
-    <version.maven-fluido-skin>2.1.0</version.maven-fluido-skin>
 
     <!-- plugin versions a..z -->
     <groovy-maven-plugin.version>5.1.0</groovy-maven-plugin.version>


### PR DESCRIPTION
Two properties in the root pom no longer override anything useful:

- **`version.plexus-utils`** pinned 4.0.2, while `org.apache.maven:maven-parent:49` manages **4.0.3** — the pin had quietly turned into a downgrade rather than the bump it was when it was added.
- **`version.maven-fluido-skin`** restated 2.1.0, exactly the value `org.apache:apache:39` already sets.

`mvn help:effective-pom` resolves plexus-utils to 4.0.3 and the skin to 2.1.0 with both lines gone. Part of a sweep across the Maven repositories for local pom properties that no longer override anything useful.

Generated-by: Claude Opus 5 (1M context)
