### PR TITLE
Drop the versions.junit5 property the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
     <buildnumber-maven-plugin.version>3.3.0</buildnumber-maven-plugin.version>
     <groovy-maven-plugin.version>5.1.0</groovy-maven-plugin.version>
     <mrm.version>1.7.1</mrm.version>
-    <versions.junit5>5.14.4</versions.junit5>
     <junit-platform-launcher.version>1.14.4</junit-platform-launcher.version>
     <takari-provisio.version>1.1.3</takari-provisio.version>
 


### PR DESCRIPTION
`org.apache.maven:maven-parent:49` already sets `versions.junit5` to **5.14.4** — the identical value — and it is the only pom that reads the property: nothing in this repository references `${versions.junit5}`. The local copy therefore changes nothing and simply has to be kept in step with the parent by hand.

Targets `mvnd-1.x`. The master branch gets its own sweep in a separate PR. Part of a sweep across the Maven repositories for local pom properties that no longer override anything.

Generated-by: Claude Opus 5 (1M context)
