### PR TITLE
Delay github-actions bumps until the ASF action allowlist catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,17 @@ updates:
     schedule:
       interval: "daily"
 
+  # The apache org only permits action SHAs listed in
+  # apache/infrastructure-actions/approved_patterns.yml. INFRA's allowlist
+  # review lags an upstream release by roughly a week, and a PR opened before
+  # the new SHA lands there gets startup_failure with no check attached to the
+  # PR at all. The cooldown holds the bump until the allowlist has caught up.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 10
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -36,6 +43,7 @@ updates:
       - "backport"
       - "dependencies"
 
+  # Same allowlist cooldown as the master github-actions entry above.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -44,3 +52,5 @@ updates:
     labels:
       - "backport"
       - "dependencies"
+    cooldown:
+      default-days: 10


### PR DESCRIPTION
The apache org only permits action SHAs present in [`apache/infrastructure-actions/approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml). When a bump PR is opened before INFRA's allowlist review lands the new SHA, `Early Access` ends in `startup_failure` and **no check is attached to the PR at all** — it reads as if CI were never configured for the branch.

Dependabot's built-in cooldown is 3 days; INFRA's turnaround has been closer to a week. `graalvm/setup-graalvm` v1.6.4 was released 06 Aug, the PRs opened 10 Aug, and the SHA was allowlisted 12 Aug in apache/infrastructure-actions#1165 — so #1723 and #1724 both sat dead until a manual `@dependabot rebase`. The same thing silently killed the 1.6.0, 1.6.1 and 1.6.2 bumps, all closed unmerged.

10 days clears the observed gap with margin. The cost is that every action bump, allowlisted or not, waits that long. It is not a guarantee — if a future review is slower, the fallback is still `@dependabot rebase` once the SHA appears.

Only master's `dependabot.yml` is in scope: Dependabot reads its config solely from the default branch, so the copy on `mvnd-1.x` is inert and the `target-branch: mvnd-1.x` entries here are what actually drive that branch's PRs.

Generated-by: Claude Opus 5 (1M context)