### PR TITLE
Drop the unused maven-resolver-transport-wagon management entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,11 +230,6 @@
         <artifactId>maven-resolver-connector-basic</artifactId>
         <version>${maven.resolver.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-transport-wagon</artifactId>
-        <version>${maven.resolver.version}</version>
-      </dependency>
 
       <!-- Only for MessageBuilder/MessageUtils -->
       <dependency>


### PR DESCRIPTION
`maven-resolver-transport-wagon` sat in `<dependencyManagement>` but is the only occurrence of that artifactId anywhere in the repository — no module declares it, and it appears in no dependency tree across the 11 modules, so the managed version was pinning nothing.

This is not a statement about the transport itself: Resolver still ships it as a first-class transport alongside `-file`, `-classpath` and `-http`, and it is not deprecated. It only stops mvnd holding a version opinion about something it never resolves.

Verified: `mvn dependency:tree -Dincludes=org.apache.maven.resolver:maven-resolver-transport-wagon` matches nothing across all 11 modules, and `dependency:list` gives a byte-identical 54-artifact resolved set before and after.

*This change was created with AI assistance.*