### PR TITLE
Stop dependabot from offering provisio 2 on mvnd-1.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,13 @@ updates:
     labels:
       - "backport"
       - "dependencies"
+    # provisio 2.0.0 rejects duplicate archive entries, and every released
+    # Maven 3 distribution carries one: lib/jansi-native is written twice as a
+    # directory entry. Master is unaffected because it builds Maven 4, whose
+    # distribution has neither. See apache/maven#12778.
+    ignore:
+      - dependency-name: "ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin"
+        versions: [ "[2.0.0,)" ]
 
   # Same allowlist cooldown as the master github-actions entry above.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
#1694 fails on every job with:

```
java.io.IOException: Duplicate archive output path lib/jansi-native in
  ~/.m2/repository/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.tar.gz
```

The duplicate is real and it is Maven's. `lib/jansi-native/` is written twice as a **directory** entry — it is the only duplicated path in the archive, and no file entry is duplicated. Two fileSets in `apache-maven/src/main/assembly/component.xml` both materialise it: the native-library fileSet whose `<include>**</include>` matches directories, and the `src/lib` fileSet that carries `jansi-native/README.txt`. Present in 3.8.8, 3.9.9 and 3.9.16 alike.

provisio 1.1.3 tolerated it; 2.0.0 added a duplicate check and does not. Since 3.9.x is already released, no change to Maven helps this branch — `mvnd-1.x` cannot move to provisio 2 at all.

Master is unaffected and already runs provisio 2.0.0, because it builds Maven 4.0.0-rc-6, whose distribution has zero duplicate entries and no `jansi-native` directory.

Filed as apache/maven#12778, with a fix for future 3.9.x releases in apache/maven#12779. The other half belongs upstream in provisio: a duplicate *directory* entry is harmless and should not be an error.

Supersedes #1694.

*This change was created with AI assistance.*