### PR TITLE
Bump graalvm/setup-graalvm to v1.6.6 in release.yaml (mvnd-1.x)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up GraalVM'
-        uses: graalvm/setup-graalvm@f60d4ea89f14098520aea588431217bbd9551570 # v1.6.5
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1.6.6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'
@@ -175,7 +175,7 @@ jobs:
           echo "VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: 'Set up GraalVM'
-        uses: graalvm/setup-graalvm@f60d4ea89f14098520aea588431217bbd9551570 # v1.6.5
+        uses: graalvm/setup-graalvm@0426e2e191540e8514dff98dc52a5f5146a2a276 # v1.6.6
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm'


### PR DESCRIPTION
`early-access.yaml` on this line was already moved to `graalvm/setup-graalvm` v1.6.6 since v1.6.5's SHA was never added to the ASF org's GitHub Actions allowlist (`apache/infrastructure-actions/approved_patterns.yml`), so any run using it fails with `startup_failure` before a job starts. `release.yaml`'s two occurrences were still pinned to v1.6.5 and would hit the same failure; both are now on v1.6.6, matching `early-access.yaml` and matching master (#1770).
